### PR TITLE
feat: add *BSD support

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -520,6 +520,18 @@ def get_package_manager() -> PackageManager | None:
             )
         logos_9_packages = ""
         incompatible_packages = ""  # appimagelauncher handled separately
+    elif shutil.which('pkg') is not None:  # freebsd ghostbsd
+        install_command = ["pkg", "-y", "install"]  # noqa: E501
+        download_command = ["pkg", "fetch", "-d"]  # noqa: E501
+        remove_command = ["pkg", "-y", "delete"]  # noqa: E501
+        query_command = ["pkg", "info"]
+        query_prefix = ''
+        packages = (
+            "cabextract 7-zip samba416 "  # wine
+            "wget gsed gnugrep gawk curl "  # other
+        )  # noqa: E501
+        logos_9_packages = ""  # FIXME: Missing Logos 9 Packages
+        incompatible_packages = ""  # appimagelauncher handled separately
     elif os_name == "org.freedesktop.platform":
         # Flatpak
         # Dependencies are managed by the flatpak


### PR DESCRIPTION
Steps:

- Download GhostBSD XFCE
- Install to Disk/VM
- Boot into it
- Open terminal
- sudo pkg install -g "GhostBSD*-dev"
- sudo pkg install vim rsync git wget curl gsed gnugrep gawk samba416 7-zip cabextract wine-devel winetricks
- git clone https://github.com/FaithLife-Community/LogosLinuxInstaller
- cd LogosLinuxInstaller
- chmod 700 ./scripts/ensure*
- ./scripts/ensure-python.sh
- ensure-venv fails if run from fish and without the export
- bash
- export LD_LIBRARY_PATH=/opt/lib
- ./scripts/ensure-venv.sh
- /opt/bin/python3 -m venv venv
- source ./venv/bin/activate
- pip install .
- pip install --upgrade pip
- pip install wheel

And now you're ready to go! At least you would be, if sqlite3 was being properly loaded. This seems to be a new problem since I first worked on this and is some issue with the python ensure. I tried the following to no avail.

---
Fixes #14. There is one blocking issue and one additional problem.

I have added install pointers to the wiki. It presently requires use of the `ports` tool to get different versions of Wine and Python, but, as noted below, we don't have the Python version we need.

- ~~[x] This is blocked until FreeBSD has a working Python 3.12 package. As it stands, it is not yet ported. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267515 https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271673~~
- [ ] No AppImage support without: See: https://github.com/AppImage/AppImageKit/issues/98. Better solution is #316 

This is untested. This PR has been opened as a base working model. Of the testing I did do, I worked on GhostBSD.

Some of the commands we use are GNU versions of commands (e.g., sed, grep) and therefore they may not work out of the box on *BSD.

Until we can build it in GitHub, you will have to run from source or pip. Once you activate the Python virtual environment (see [CONTRIBUTING](https://github.com/FaithLife-Community/LogosLinuxInstaller/blob/main/CONTRIBUTING.md)), you will then need to install some Python modules.

For newer Wine, you may need to use ports.