### PR TITLE
fix: ensure user agrees to the EULA even in non-interactive settings

### DIFF
--- a/ou_dedetai/app.py
+++ b/ou_dedetai/app.py
@@ -124,10 +124,11 @@ class App(abc.ABC):
 
         return answer
 
-    def approve_or_exit(self, question: str, context: Optional[str] = None):
+    def approve_or_exit(self, question: str, context: Optional[str] = None) -> bool:
         """Asks the user a question, if they refuse, shutdown"""
         if not self.approve(question, context):
             self.exit(f"User refused the prompt: {question}")
+        return True
 
     def approve(self, question: str, context: Optional[str] = None) -> bool:
         """Asks the user a y/n question"""

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -241,6 +241,13 @@ class EphemeralConfiguration:
     # Start of values just set via cli arg
     faithlife_install_passive: bool = False
     app_run_as_root_permitted: bool = False
+    agreed_to_faithlife_terms: bool = False
+    """The user expressed clear agreement with faithlife's terms.
+    Normally the MSI would prompt for this as well.
+
+    DO NOT set this unless clear beyond a reasonable doubt the user knows
+    what they're doing - agreeing to https://faithlife.com/terms
+    """
 
     @classmethod
     def from_legacy(cls, legacy: LegacyConfiguration) -> "EphemeralConfiguration":

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -90,12 +90,15 @@ class GuiApp(App):
             super()._status(message, percent)
 
     def approve(self, question: str, context: str | None = None) -> bool:
-        return messagebox.askquestion(question, context) == 'yes'
+        if context is None:
+            context = ""
+        message = f"{context}\n{question}"
+        return messagebox.askquestion(question, message.strip()) == 'yes'
 
     def _exit(self, reason: str, intended: bool = False):
         # Create a little dialog before we die so the user can see why this happened
         if not intended:
-            gui.show_error(reason, detail=constants.SUPPORT_MESSAGE, fatal=True)
+            gui.show_error(reason, detail=constants.SUPPORT_MESSAGE, fatal=False)
         self.root.destroy()
     
     @property

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -76,12 +76,18 @@ def get_parser():
     )
     cfg.add_argument(
         '-P', '--passive', action='store_true',
-        help='run product installer non-interactively',
+        help='run product installer non-interactively. '
+        'Consider agreeing to the terms as well --i-agree-to-faithlife-terms',
     )
     cfg.add_argument(
         '-y', '--assume-yes', action='store_true',
         help='Assumes yes (or default) to all prompts. '
-        'Useful for entirely non-interactive installs',
+        'Useful for entirely non-interactive installs. '
+        'Consider agreeing to the terms as well --i-agree-to-faithlife-terms',
+    )
+    cfg.add_argument(
+        '--i-agree-to-faithlife-terms', action='store_true',
+        help='By passing this flag you agree to https://faithlife.com/terms',
     )
     cfg.add_argument(
         '-q', '--quiet', action='store_true',
@@ -229,11 +235,18 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
             message = f"Custom binary path does not exist: \"{args.custom_binary_path}\"\n"  # noqa: E501
             parser.exit(status=1, message=message)
 
+    if args.assume_yes and not args.i_agree_to_faithlife_terms:
+        message = "Non-interactive installations MUST also agree to the EULA https://faithlife.com/terms via the flag --i-agree-to-faithlife-terms\n"  # noqa: E501
+        parser.exit(status=1, message=message)
+
     if args.assume_yes:
         ephemeral_config.assume_yes = True
 
     if args.passive or args.assume_yes:
         ephemeral_config.faithlife_install_passive = True
+
+    if args.i_agree_to_faithlife_terms:
+        ephemeral_config.agreed_to_faithlife_terms = True
 
 
     def cli_operation(action: str) -> Callable[[EphemeralConfiguration], None]:

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -46,7 +46,7 @@ class TUI(App):
         # else:
         #    self.title = f"Welcome to {constants.APP_NAME} ({constants.LLI_CURRENT_VERSION})"  # noqa: E501
         self.console_message = "Starting TUI…"
-        self.llirunning = True
+        self.is_running = True
         self.active_progress = False
         self.tmp = ""
 
@@ -329,9 +329,17 @@ class TUI(App):
             logging.error(f"An error occurred in end_curses(): {e}")
             raise
 
+    def _exit(self, reason, intended = False):
+        message = f"Exiting {constants.APP_NAME} due to {reason}…"
+        if not intended:
+            message += "\n" + constants.SUPPORT_MESSAGE
+        self._status(message)
+        time.sleep(30)
+        self.end(None, None)
+
     def end(self, signal, frame):
         logging.debug("Exiting…")
-        self.llirunning = False
+        self.is_running = False
         curses.endwin()
 
     def update_main_window_contents(self):
@@ -401,7 +409,7 @@ class TUI(App):
         check_resize_last_time = last_time = time.time()
         self.logos.monitor()
 
-        while self.llirunning:
+        while self.is_running:
             if self.window_height >= 10 and self.window_width >= 35:
                 self.terminal_margin = 2
                 if not self.resizing:
@@ -415,6 +423,8 @@ class TUI(App):
                             self.active_screen.screen_id,
                             self.choice_q.get(),
                         )
+                        if self.active_screen.screen_id == 2:
+                            self.tui_screens.pop()
 
                     if len(self.tui_screens) == 0:
                         self.active_screen = self.menu_screen
@@ -526,7 +536,7 @@ class TUI(App):
         if choice is None or choice == "Exit":
             logging.info("Exiting installation.")
             self.tui_screens = []
-            self.llirunning = False
+            self.is_running = False
         elif choice.startswith("Install"):
             self.reset_screen()
             self.installer_step = 0

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -349,7 +349,12 @@ def install_msi(app: App):
 
     # Add passive mode if specified
     if app.conf._overrides.faithlife_install_passive is True:
-        exe_args.append("/passive")
+        # Ensure the user agrees to the EULA. Exit if they don't.
+        if (
+            app.conf._overrides.agreed_to_faithlife_terms or
+            app.approve_or_exit("Do you agree to Faithlife's EULA? https://faithlife.com/terms")
+        ):
+            exe_args.append("/passive")
 
     # Add MST transform if needed
     release_version = app.conf.installed_faithlife_product_release or app.conf.faithlife_product_version  # noqa: E501


### PR DESCRIPTION
Another route we could go is always doing a passive install, as now we have the proper EULA checks

Fixes: #241

Tested:

Scenario CLI passive:
- passed args --install-app --passive
- Asked on CLI to agree to the EULA
- install MSI success

Scenario CLI assume yes:
- passed args --install-app -y
- Installer exits requiring the --i-agree-to-faithlife-terms flag

Scenario CLI assume yes agreed to terms:
- passed args --install-app -y --i-agree-to-faithlife-terms
- Install MSI success

Scenario GUI passive:
- passed env DIALOG=tk and args --passive
- Asked on the GUI to agree to the EULA
- accepted
- install MSI success

Scenario GUI passive decline:
- passed env DIALOG=tk and args --passive
- Asked on the GUI to agree to the EULA
- declined
- Error dialog, then exit

Scenario TUI passive:
- passed args --passive
- Asked on the TUI to agree to the EULA
- accepted
- install MSI success

Scenario TUI passive decline:
- passed args --passive
- Asked on the TUI to agree to the EULA
- declined
- Shown status why we're exiting then closes after 30s

