### PR TITLE
feat: add install GUI

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -438,7 +438,7 @@ class PersistentConfiguration:
                 if (isinstance(v, str) and v.startswith(self.install_dir)): #noqa: E501
                     output[k] = utils.get_relative_path(v, self.install_dir)
 
-            portable_config_path = os.path.expanduser(self.install_dir + f"/{constants.BINARY_NAME}.json")
+            portable_config_path = os.path.expanduser(self.install_dir + f"/{constants.BINARY_NAME}.json") #noqa: E501
             self.write_json_file(output, portable_config_path)
 
         self.write_json_file(output, config_file_path)
@@ -766,6 +766,8 @@ class Config:
         # Return the full path so we the callee doesn't need to think about it
         if self._raw.wine_binary is not None and not Path(self._raw.wine_binary).exists() and (Path(self.install_dir) / self._raw.wine_binary).exists(): # noqa: E501
             return str(Path(self.install_dir) / self._raw.wine_binary)
+        if not Path(output).exists():
+            logging.warning(f"Wine binary {output} doesn't exist")
         return output
 
     @wine_binary.setter

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -59,7 +59,7 @@ if RUNMODE == 'snap':
 else:
     CACHE_DIR = Path(os.getenv('XDG_CACHE_HOME', Path.home() / '.cache' / 'FaithLife-Community')) #noqa: E501
 
-XDG_DATA_HOME = Path(os.getenv('XDG_DATA_HOME', Path.home() / '.local/share' / 'FaithLife-Community'))
+XDG_DATA_HOME = Path(os.getenv('XDG_DATA_HOME', Path.home() / '.local/share' / 'FaithLife-Community')) #noqa: E501
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", "~/.config") + "/FaithLife-Community"
 STATE_DIR = os.getenv("XDG_STATE_HOME", "~/.local/state") + "/FaithLife-Community"
 

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -153,11 +153,11 @@ class StatusGui(Frame):
         self.progress.state(['disabled'])
 
 
-class RecoveryGui(StatusGui):
-    def __init__(self, root, *args, **kwargs):
-        super(RecoveryGui, self).__init__(root, **kwargs)
+class StatusWithLabelGui(StatusGui):
+    def __init__(self, root, label: str, *args, **kwargs):
+        super(StatusWithLabelGui, self).__init__(root, **kwargs)
 
-        self.app_label = Label(self, text="Recovering FaithLife app")
+        self.app_label = Label(self, text=label)
         self.app_label.grid(column=0, row=0, columnspan=3, sticky='we', pady=2)  # noqa: E501
         Separator(self, orient='horizontal').grid(column=0, row=1)
         self.message_label.grid(column=0, row=2, columnspan=3, sticky='we', pady=2)  # noqa: E501

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -44,10 +44,10 @@ class ChoiceGui(Frame):
         # Place widgets.
         row = 0
         self.question_label.grid(column=0, row=row, sticky='nws', pady=2)
-        self.answer_dropdown.grid(column=1, row=row, sticky='w', pady=2)
+        self.answer_dropdown.grid(column=1, row=row, sticky='w', pady=2, columnspan=2)
         row += 1
-        self.cancel_button.grid(column=3, row=row, sticky='e', pady=2)
-        self.okay_button.grid(column=4, row=row, sticky='e', pady=2)
+        self.cancel_button.grid(column=1, row=row, sticky='e', pady=2)
+        self.okay_button.grid(column=2, row=row, sticky='e', pady=2)
 
 
 class InstallerGui(Frame):
@@ -148,7 +148,9 @@ class StatusGui(Frame):
             self,
             mode='indeterminate',
             orient='horizontal',
-            variable=self.progressvar
+            variable=self.progressvar,
+            # This length sets the minimum length of the progress bar
+            length=350
         )
         self.progress.state(['disabled'])
 
@@ -157,18 +159,16 @@ class StatusWithLabelGui(StatusGui):
     def __init__(self, root, label: str, *args, **kwargs):
         super(StatusWithLabelGui, self).__init__(root, **kwargs)
 
-        self.app_label = Label(self, text=label)
-        self.app_label.grid(column=0, row=0, columnspan=3, sticky='we', pady=2)  # noqa: E501
-        Separator(self, orient='horizontal').grid(column=0, row=1)
-        self.message_label.grid(column=0, row=2, columnspan=3, sticky='we', pady=2)  # noqa: E501
-        self.progress.grid(column=0, row=3, columnspan=3, sticky='we', pady=2)  # noqa: E501
+        self.app_label = Label(self, text=label, font=('TkDefaultFont', 16))
+        self.app_label.grid(column=0, row=0, sticky='we', pady=2)
+        Separator(self, orient='horizontal').grid(column=0, row=1, sticky='ew')
+        self.message_label.grid(column=0, row=2, sticky='we', pady=2)
+        self.progress.grid(column=0, row=3, sticky='we', pady=2)
 
 
 class ControlGui(StatusGui):
     def __init__(self, root, *args, **kwargs):
         super(ControlGui, self).__init__(root, **kwargs)
-        self.config(padding=5)
-        self.grid(row=0, column=0, sticky='nwes')
 
         # Run/install app button
         self.app_buttonvar = StringVar()

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -251,7 +251,6 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
         'backup',
         'create_shortcuts',
         'edit_config',
-        'install_app',
         'install_dependencies',
         'install_icu',
         'remove_index_files',
@@ -283,6 +282,8 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
                 ephemeral_config.wine_args = getattr(args, 'wine')
             run_action = cli_operation(arg)
             break
+    if getattr(args, "install_app"):
+        run_action = install_app
     if run_action is None:
         run_action = run_control_panel
     logging.debug(f"{run_action=}")
@@ -293,7 +294,7 @@ def run_control_panel(ephemeral_config: EphemeralConfiguration):
     dialog = ephemeral_config.dialog or system.get_dialog()
     logging.info(f"Using DIALOG: {dialog}")
     if dialog == 'tk':
-        gui_app.control_panel_app(ephemeral_config)
+        gui_app.start_gui_app(ephemeral_config)
     else:
         try:
             curses.wrapper(tui_app.control_panel_app, ephemeral_config)
@@ -308,6 +309,14 @@ def run_control_panel(ephemeral_config: EphemeralConfiguration):
         except Exception as e:
             logging.error(f"An error occurred in run_control_panel(): {e}")
             raise e
+
+def install_app(ephemeral_config: EphemeralConfiguration):
+    dialog = ephemeral_config.dialog or system.get_dialog()
+    logging.info(f"Using DIALOG: {dialog}")
+    if dialog == 'tk':
+        gui_app.start_gui_app(ephemeral_config, install_only=True)
+    else:
+        cli.CLI(ephemeral_config).install_app()
 
 
 def setup_config() -> Tuple[EphemeralConfiguration, Callable[[EphemeralConfiguration], None]]: #noqa: E501

--- a/ou_dedetai/repair.py
+++ b/ou_dedetai/repair.py
@@ -54,7 +54,7 @@ def detect_broken_install(
 def run_under_app(ephemeral_config: EphemeralConfiguration, func: Callable[[App], None]): #noqa: E501
     dialog = ephemeral_config.dialog or ou_dedetai.system.get_dialog()
     if dialog == 'tk':
-        return ou_dedetai.gui_app.control_panel_app(ephemeral_config, func)
+        return ou_dedetai.gui_app.start_gui_app(ephemeral_config, func)
     else:
         app = ou_dedetai.cli.CLI(ephemeral_config)
         func(app)

--- a/snap/bin/run.sh
+++ b/snap/bin/run.sh
@@ -10,6 +10,9 @@ export FLPRODUCT="$1"
 shift
 echo "Starting $FLPRODUCT"
 export TARGETVERSION="10"
+# Default to the GUI if the DIALOG env is not set.
+# If you want to use a different UI, set the DIALOG env
+export DIALOG="${DIALOG:-tk}"
 
 # Ensure Faithlife app is installed.
 app_exe="$(find "${INSTALLDIR}/data/wine64_bottle" -wholename "*${FLPRODUCT}/${FLPRODUCT}.exe" 2>/dev/null)"


### PR DESCRIPTION
Leverages the generic nature of App to create a dialog that just does the installation

Useful in flatpak/snap if we want to start the install process and show the user feedback in a GUI fashion

Tested:
- setting DIALOG=tk
- passing arg --install-app
- observed install window opened, and install success

Also tested:
- setting DIALOG=tk
- passing neither -C or --install-app
- observed control panel opened