### PR TITLE
feat: detect first time installs

### DIFF
--- a/ou_dedetai/app.py
+++ b/ou_dedetai/app.py
@@ -132,7 +132,7 @@ class App(abc.ABC):
 
     def approve(self, question: str, context: Optional[str] = None) -> bool:
         """Asks the user a y/n question"""
-        question = (f"{context}\n" if context else "") + question
+        question = (f"{context}\n\n" if context else "") + question
         options = ["Yes", "No"]
         return self.ask(question, options) == "Yes"
 

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -478,6 +478,18 @@ def get_logos_appdata_dir(
     return f'{wine_prefix}/drive_c/users/{wine_user}/AppData/Local/{faithlife_product}'
 
 
+def get_logos_user_id(
+    logos_appdata_dir: str
+) -> Optional[str]:
+    logos_data_path = Path(logos_appdata_dir) / "Data"
+    contents = os.listdir(logos_data_path)
+    children = [logos_data_path / child for child in contents]
+    file_children = [child for child in children if child.is_dir()]
+    if file_children and len(file_children) > 0:
+        return file_children[0].name
+    else:
+        return None
+
 class Config:
     """Set of configuration values. 
     
@@ -759,6 +771,14 @@ class Config:
             wine_user,
             self.faithlife_product
         )
+
+    @property
+    def _logos_user_id(self) -> Optional[str]:
+        """Name of the Logos user id throughout the app"""
+        logos_appdata_dir = self._logos_appdata_dir
+        if logos_appdata_dir is None:
+            return None
+        return get_logos_user_id(logos_appdata_dir)
 
     @property
     # This used to be called WINEPREFIX

--- a/ou_dedetai/database.py
+++ b/ou_dedetai/database.py
@@ -1,0 +1,152 @@
+import abc
+import contextlib
+import logging
+import sqlite3
+import inotify.adapters # type: ignore
+from pathlib import Path
+from typing import Any, Optional
+
+
+class FaithlifeDatabase(contextlib.AbstractContextManager):
+    """Class for interacting with internal Faithlife databases.
+    
+    Use with python's context manager"""
+
+    logos_app_dir: Path
+    logos_user_id: str
+    _db: Optional[sqlite3.Connection]
+
+    def __init__(
+        self,
+        logos_app_dir: Path,
+        logos_user_id: str
+    ):
+        self.logos_app_dir = logos_app_dir
+        self.logos_user_id = logos_user_id
+
+    @abc.abstractmethod
+    def _database_path(self) -> Path:
+        """Path to the database"""
+        pass
+
+    def execute_sql(
+        self,
+        sql_statement: str,
+        parameters: list[str] = list(frozenset())
+    ) -> list[Any]:
+        return self.database.execute(sql_statement, parameters).fetchall()
+        
+    def fetch_one(
+        self,
+        sql_statement: str,
+        parameters: list[str] = list(frozenset())
+    ) -> Optional[Any]:
+        contents = self.execute_sql(sql_statement, parameters)
+        if contents and len(contents) > 0:
+            # Content comes in as a tuple, trailing , unpacks first argument
+            content, = contents[0]
+            return content
+        return None
+
+    @property
+    def database(self) -> sqlite3.Connection:
+        if not self._db:
+            self._db = self._connect()
+        return self._db
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(str(self._database_path()), autocommit=True)
+
+    def close(self):
+        if self._db:
+            self._db.close()
+
+    def __enter__(self):
+        self._db = self._connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._db:
+            self._db.__exit__(exc_type, exc_value, traceback)
+            self._db = None
+
+
+class LocalUserPreferencesManager(FaithlifeDatabase):
+    def _database_path(self):
+        return self.logos_app_dir / "Documents" / self.logos_user_id / "LocalUserPreferences" / "PreferencesManager.db" #noqa: E501
+    
+    @property
+    def app_local_preferences(self) -> Optional[str]:
+        return self.fetch_one(
+            "SELECT Data FROM Preferences WHERE `Type`='AppLocalPreferences' LIMIT 1" #noqa: E501
+        )
+    
+    @app_local_preferences.setter
+    def app_local_preferences(self, value: str):
+        self.execute_sql(
+            "UPDATE Preferences SET Data= ? WHERE `Type`='AppLocalPreferences'", #noqa: E501
+            [value]
+        )
+    
+    # Need to override __enter__ to return the proper type.
+    def __enter__(self):
+        super().__enter__()
+        return self
+
+
+# FIXME: refactor into FaithlifeDatabase class
+def watch_db(path: str, sql_statements: list[str]):
+    """Runs SQL statements against a sqlite db once to start with, then again every time
+    The sqlite db is written to.
+    
+    Handles -wal/-shm as well
+
+    This function may run infinitely, spawn it on it's own thread
+    """
+    # Silence inotify logs
+    logging.getLogger('inotify').setLevel(logging.CRITICAL)
+    i = inotify.adapters.Inotify()
+    i.add_watch(path)
+
+    def execute_sql(cur):
+        # logging.debug(f"Executing SQL against {path}: {sql_statements}")
+        for statement in sql_statements:
+            try:
+                cur.execute(statement)
+            # Database may be locked, keep trying later.
+            except sqlite3.OperationalError:
+                logging.exception("Best-effort db update failed")
+                pass
+
+    with sqlite3.connect(path, autocommit=True) as con:
+        cur = con.cursor()
+
+        # Execute once before we start the loop
+        execute_sql(cur)
+        swallow_one = True
+
+        # Keep track of if we've added -wal and -shm are added yet
+        # They may not exist when we start
+        watching_wal_and_shm = False
+        for event in i.event_gen(yield_nones=False):
+            (_, type_names, _, _) = event
+            # These files may not exist when it's executes for the first time
+            if (
+                not watching_wal_and_shm
+                and Path(path + "-wal").exists()
+                and Path(path + "-shm").exists()
+            ):
+                i.add_watch(path + "-wal")
+                i.add_watch(path + "-shm")
+                watching_wal_and_shm = True
+
+            if 'IN_MODIFY' in type_names or 'IN_CLOSE_WRITE' in type_names:
+                # Check to make sure that we aren't responding to our own write
+                if swallow_one:
+                    swallow_one = False
+                    continue
+                execute_sql(cur)
+                swallow_one = True
+        # Shouldn't be possible to get here, but on the off-chance it happens, 
+        # we'd like to know and cleanup
+        logging.debug(f"Stopped watching {path}")

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -96,7 +96,7 @@ class GuiApp(App):
     def approve(self, question: str, context: str | None = None) -> bool:
         if context is None:
             context = ""
-        message = f"{context}\n{question}"
+        message = f"{question}\n{context}"
         return messagebox.askquestion(question, message.strip()) == 'yes'
 
     def _exit(self, reason: str, intended: bool = False):

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -158,12 +158,10 @@ class LogosManager:
         if self.app.conf._logos_appdata_dir is None:
             return
         logos_appdata_dir = Path(self.app.conf._logos_appdata_dir)
-        # The glob here is for a user identifier
-        db_glob = './Documents/*/LocalUserPreferences/PreferencesManager.db'
-        results = list(logos_appdata_dir.glob(db_glob))
-        if not results:
+        logos_user_id = self.app.conf._logos_user_id
+        if not logos_user_id:
             return None
-        db_path = results[0]
+        db_path = logos_appdata_dir / "Documents" / logos_user_id / "LocalUserPreferences" / "PreferencesManager.db" #noqa: E501
         sql = (
             """UPDATE Preferences SET Data='<data """ +
             ('OptIn="true"' if val else 'OptIn="false"') +
@@ -178,12 +176,10 @@ class LogosManager:
         if self.app.conf._logos_appdata_dir is None:
             return
         logos_appdata_dir = Path(self.app.conf._logos_appdata_dir)
-        # The glob here is for a user identifier
-        db_glob = './Data/*/UpdateManager/Updates.db'
-        results = list(logos_appdata_dir.glob(db_glob))
-        if not results:
+        logos_user_id = self.app.conf._logos_user_id
+        if logos_user_id is None:
             return None
-        db_path = results[0]
+        db_path = logos_appdata_dir / "Data" / logos_user_id / "UpdateManager" / "Updates.db" #noqa :E501
         # FIXME: I wonder if we can use the result of these deletion using RETURNING
         # Then we could notify the user that there are updates.
         # If we do that we'd have to consider if their other resources are up to date

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -8,6 +8,7 @@ import logging
 import psutil
 import threading
 
+from ou_dedetai import database
 from ou_dedetai.app import App
 
 from . import system
@@ -167,7 +168,7 @@ class LogosManager:
             ('OptIn="true"' if val else 'OptIn="false"') +
             """ StartDownloadHour="0" StopDownloadHour="0" MarkNewResourcesAsCloud="true" />' WHERE Type='UpdateManagerPreferences'""" #noqa: E501
         )
-        self.app.start_thread(utils.watch_db, str(db_path), [sql])
+        self.app.start_thread(database.watch_db, str(db_path), [sql])
 
     def prevent_logos_updates(self):
         """Edits Logos' internal database to remove pending installers
@@ -201,7 +202,7 @@ class LogosManager:
             "UPDATE Resources SET Status=1, UpdateId=NULL WHERE UpdateId IS NOT NULL "+
                 "AND UpdateId NOT IN (SELECT UpdateId FROM Updates)"
         ]
-        self.app.start_thread(utils.watch_db, str(db_path), sql)
+        self.app.start_thread(database.watch_db, str(db_path), sql)
 
     # Also noticed if the database Data/*/CloudResourceManager/CloudResources.db 
     # table TransitionStates has a ResourceId that isn't registered in UpdateManager,

--- a/ou_dedetai/repair.py
+++ b/ou_dedetai/repair.py
@@ -152,11 +152,15 @@ def detect_and_recover(ephemeral_config: EphemeralConfiguration):
                 f"{persistent_config.faithlife_product}?"
             )
             context=(
-                "The following recovery method is helpful if resource downloading is "
-                "crashing, but may not be required.\n"
+                "The following recovery method is not recommended unless "
+                "downloading resources is crashing "
+                "(i.e. the 'Continue' button causes a crash).\n"
                 "You will need to download your resources manually in the Library tab. "
                 "Use the filter 'Not on This Device' and use CTRL+A to "
-                "make this easier."
+                "make this easier.\n"
+                "After downloading all your resources, wait until after it indexes "
+                "before using the application - some features may crash if they are "
+                "opened prematurely."
             )
 
             if not app.approve(question=question, context=context):
@@ -182,6 +186,8 @@ def detect_and_recover(ephemeral_config: EphemeralConfiguration):
                     "UPDATE Preferences SET Data='<data/>' WHERE `Type`='AppLocalPreferences'" #noqa: E501
                 ]
             )
+            # XXX: leave a note to future us to let us know the user skipped this during the installtion.
+            # Useful if this operation has side effects in the future, being able to tell that the user did this WAYYYY back when they first installed logos
 
             app.status(
                 f"Recovery attempt of {app.conf.faithlife_product} complete. "

--- a/ou_dedetai/repair.py
+++ b/ou_dedetai/repair.py
@@ -23,7 +23,6 @@ import ou_dedetai.utils
 
 class FailureType(Enum):
     FailedUpgrade = auto()
-    InFirstRunState = auto()
 
 
 def detect_broken_install(
@@ -63,22 +62,10 @@ def detect_broken_install(
                 and 'FirstRunDialogWizardState="ResourceBundleSelection"' in db.app_local_preferences #noqa: E501
             ):
                 # We're in first-run state.
-                first_run = True
+                first_run = True # noqa: F841
     except Exception:
         logging.exception("Failed to check to see if we needed to recover")
         pass
-
-    if first_run:
-        # Perhaps in the future we can be a little less hash with this, however there
-        # are so many weird edge cases in this state, it's far more reliable to simply
-        # consider this an error.
-        #
-        # We can only tell we're in a first run state after the user has logged in
-        # which suggests that at some point in the past the user logged in, attempted
-        # to downloaded resources, then closed (probably a crash), then started OD back
-        # up, where this code path would trigger. In this scenario, still being in a
-        # first run state after what is now the second run is not desirable.
-        return FailureType.InFirstRunState
 
     return None
 
@@ -140,69 +127,6 @@ def detect_and_recover(ephemeral_config: EphemeralConfiguration):
             time.sleep(1)
             ou_dedetai.installer.install(app)
             app.status(f"Recovery attempt of {app.conf.faithlife_product} complete")
-        run_under_app(ephemeral_config, _run)
-    elif detected_failure == FailureType.InFirstRunState:
-        def _run(app: App):
-            question=(
-                "Do you want to skip the first run dialog and go straight into "
-                f"{persistent_config.faithlife_product}?"
-            )
-            manual_recovery_steps = (
-                "Manual Recovery Steps (after this completes):\n"
-                "- Open the Library tool\n"
-                "- Use the filter 'Not on This Device'\n"
-                "- Press CTRL+A to select all resources\n"
-                "- On the right pane (hit the i if there is none), hit Download\n"
-                "- Wait until after indexing is complete before using the application—"
-                "some features may crash if they are opened prematurely."
-            )
-            context=(
-                "The following recovery method is not recommended unless "
-                "downloading resources is crashing "
-                "(i.e. the 'Continue' button causes a crash).\n\n"
-                + manual_recovery_steps
-            )
-
-            if not app.approve(question=question, context=context):
-                return
-            app.status(f"Bypassing first-run dialog for {persistent_config.faithlife_product}") #noqa: E501
-            logos_appdata_dir = app.conf._logos_appdata_dir
-            logos_user_id = app.conf._logos_user_id
-
-            if logos_appdata_dir is None:
-                # This shouldn't happen - we use this dir when detecting this failure
-                app.status(f"Failed to recover first time resource download: can't find {app.conf.faithlife_product} dir") #noqa: E501
-                time.sleep(5)
-                return
-            if logos_user_id is None:
-                # This shouldn't happen - we use this dir when detecting this failure
-                app.status(f"Failed to recover first time resource download: can't find {app.conf.faithlife_product} user Data dir. Are you logged in?") #noqa: E501
-                time.sleep(5)
-                return
-            
-            with ou_dedetai.database.LocalUserPreferencesManager(Path(logos_appdata_dir), logos_user_id) as db: #noqa: E501
-                app_local_preferences = db.app_local_preferences
-                if app_local_preferences is None:
-                    # This shouldn't happen - we use this parameter when detecting this failure #noqa: E501
-                    app.status("Failed to recover first time resource download: couldn't verify we were in first run") #noqa: E501
-                    time.sleep(5)
-                    return
-                # Add minimal selection SelectedResourceBundleId="minimal"
-                if 'SelectedResourceBundleId' not in app_local_preferences:
-                    app_local_preferences.replace('<data ', '<data SelectedResourceBundleId="minimal"') #noqa: E501
-                db.app_local_preferences = app_local_preferences.replace(
-                    'FirstRunDialogWizardState="ResourceBundleSelection"',
-                    'FirstRunDialogWizardState="Completed"'
-                )
-            # XXX: leave a note to future us to let us know the user skipped this during the installtion.
-            # Useful if this operation has side effects in the future, being able to tell that the user did this WAYYYY back when they first installed logos
-
-            app.status(
-                f"Recovery attempt of {app.conf.faithlife_product} complete. "
-                f"{app.conf.faithlife_product} should now launch directly, "
-                "bypassing first time resource download dialog.\n\n"
-                + manual_recovery_steps
-            )
         run_under_app(ephemeral_config, _run)
 
     # FIXME: Read the LogosCrash.log and suggest other recovery methods

--- a/ou_dedetai/repair.py
+++ b/ou_dedetai/repair.py
@@ -62,10 +62,13 @@ def detect_broken_install(
                 and 'FirstRunDialogWizardState="ResourceBundleSelection"' in db.app_local_preferences #noqa: E501
             ):
                 # We're in first-run state.
-                first_run = True # noqa: F841
+                first_run = True
     except Exception:
         logging.exception("Failed to check to see if we needed to recover")
         pass
+
+    if first_run:
+        logging.warning(f"Detected a failed resource download.\n{ou_dedetai.constants.SUPPORT_MESSAGE}") #noqa: E501
 
     return None
 

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -6,8 +6,6 @@ import json
 import logging
 import os
 import queue
-import sqlite3
-import inotify.adapters # type: ignore
 import psutil
 import re
 import shutil
@@ -20,7 +18,7 @@ import time
 from ou_dedetai.app import App
 from packaging.version import Version
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from . import constants
 from . import network
@@ -652,67 +650,3 @@ def get_timestamp():
 def parse_bool(string: str) -> bool:
     return string.lower() in ['true', '1', 'y', 'yes']
 
-
-def execute_sql(path: str | Path, sql_statements: list[str]) -> list[Any]:
-    with sqlite3.connect(str(path), autocommit=True) as con:
-        cur = con.cursor()
-        for statement in sql_statements:
-            cur.execute(statement)
-        return cur.fetchall()
-
-
-def watch_db(path: str, sql_statements: list[str]):
-    """Runs SQL statements against a sqlite db once to start with, then again every time
-    The sqlite db is written to.
-    
-    Handles -wal/-shm as well
-
-    This function may run infinitely, spawn it on it's own thread
-    """
-    # Silence inotify logs
-    logging.getLogger('inotify').setLevel(logging.CRITICAL)
-    i = inotify.adapters.Inotify()
-    i.add_watch(path)
-
-    def execute_sql(cur):
-        # logging.debug(f"Executing SQL against {path}: {sql_statements}")
-        for statement in sql_statements:
-            try:
-                cur.execute(statement)
-            # Database may be locked, keep trying later.
-            except sqlite3.OperationalError:
-                logging.exception("Best-effort db update failed")
-                pass
-
-    with sqlite3.connect(path, autocommit=True) as con:
-        cur = con.cursor()
-
-        # Execute once before we start the loop
-        execute_sql(cur)
-        swallow_one = True
-
-        # Keep track of if we've added -wal and -shm are added yet
-        # They may not exist when we start
-        watching_wal_and_shm = False
-        for event in i.event_gen(yield_nones=False):
-            (_, type_names, _, _) = event
-            # These files may not exist when it's executes for the first time
-            if (
-                not watching_wal_and_shm
-                and Path(path + "-wal").exists()
-                and Path(path + "-shm").exists()
-            ):
-                i.add_watch(path + "-wal")
-                i.add_watch(path + "-shm")
-                watching_wal_and_shm = True
-
-            if 'IN_MODIFY' in type_names or 'IN_CLOSE_WRITE' in type_names:
-                # Check to make sure that we aren't responding to our own write
-                if swallow_one:
-                    swallow_one = False
-                    continue
-                execute_sql(cur)
-                swallow_one = True
-        # Shouldn't be possible to get here, but on the off-chance it happens, 
-        # we'd like to know and cleanup
-        logging.debug(f"Stopped watching {path}")

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -20,7 +20,7 @@ import time
 from ou_dedetai.app import App
 from packaging.version import Version
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from . import constants
 from . import network
@@ -119,7 +119,7 @@ def install_dependencies(app: App):
         targetversion = int(app.conf.faithlife_product_version)
     else:
         targetversion = 10
-    app.status(f"Checking {app.conf.faithlife_product} {str(targetversion)} dependencies…")
+    app.status(f"Checking {app.conf.faithlife_product} {str(targetversion)} dependencies…") #noqa: E501
 
     if targetversion == 10:
         system.install_dependencies(app, target_version=10)  # noqa: E501
@@ -651,6 +651,14 @@ def get_timestamp():
 
 def parse_bool(string: str) -> bool:
     return string.lower() in ['true', '1', 'y', 'yes']
+
+
+def execute_sql(path: str | Path, sql_statements: list[str]) -> list[Any]:
+    with sqlite3.connect(str(path), autocommit=True) as con:
+        cur = con.cursor()
+        for statement in sql_statements:
+            cur.execute(statement)
+        return cur.fetchall()
 
 
 def watch_db(path: str, sql_statements: list[str]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -330,7 +330,3 @@ class TestGeneralUtils(unittest.TestCase):
     @unittest.skip("Test requires oudedetai binary.")
     def test_update_to_latest_lli_release(self):
         pass
-
-    @unittest.skip("Test not feasible.")
-    def test_watch_db(self):
-        pass


### PR DESCRIPTION
Detect First time installs and warn the user if we're still in that state. This may be useful in debugging.

It should be noted we should never see this if there was no crash, this database flag is only set during resource download before the first run dialog is closed. The first run dialog would have had to crash in order for this to display

Opted not to manually mangle the logos database into force a non-first run state due to potential side effects that may last the entire install. It's safer to act as much like the window install as we can. If push comes to shove, we can bypass it as-needed, but it may have far-reaching side effects