### PR TITLE
fix: install arial font

### DIFF
--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -69,6 +69,9 @@ class CLI(App):
     def stop_installed_app(self):
         self.logos.stop()
 
+    def winetricks(self):
+        wine.run_winetricks(self, *(self.conf._overrides.wine_args or []))
+
     def wine(self):
         wine.run_wine_proc(
             self.conf.wine64_binary,

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -720,7 +720,7 @@ class Config:
     def winetricks_binary(self) -> str:
         """Download winetricks if it doesn't exist"""
         from ou_dedetai import system
-        # Path is now static, the installer puts a syslink here if we're using appimage
+        # Path is now static, the installer puts a symlink here if we're using appimage
         winetricks_path = Path(self.installer_binary_dir) / "winetricks"
     
         system.ensure_winetricks(

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -79,6 +79,8 @@ LEGACY_CONFIG_FILES = [
 ]
 LLI_AUTHOR = "Ferion11, John Goodman, T. H. Wright, N. Marti, N. Shaaban"
 LLI_CURRENT_VERSION = "4.0.0-beta.8"
+# This SHOULD match the version of winetricks we ship in the latest appimage
+WINETRICKS_VERSION = '20250102'
 DEFAULT_LOG_LEVEL = logging.WARNING
 LOGOS_BLUE = '#0082FF'
 LOGOS_GRAY = '#E7E7E7'

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -538,7 +538,6 @@ class ControlWindow(GuiApp):
         self.start_thread(control.restore, app=self)
 
     def install_deps(self, evt=None):
-        self.status("Installing dependencies…")
         self.start_thread(utils.install_dependencies, self)
 
     def open_file_dialog(self, filetype_name, filetype_extension):

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -291,7 +291,8 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
                 if not utils.check_appimage(ephemeral_config.wine_appimage_path):
                     e = f"{ephemeral_config.wine_appimage_path} is not an AppImage."
                     raise argparse.ArgumentTypeError(e)
-            elif arg == 'wine':
+            # Re-use this variable for either wine or winetricks execution
+            elif arg == 'wine' or arg == 'winetricks':
                 ephemeral_config.wine_args = getattr(args, 'wine')
             run_action = cli_operation(arg)
             break
@@ -426,7 +427,7 @@ def main():
     # program.
     # utils.die_if_running()
     if os.getuid() == 0 and not ephemeral_config.app_run_as_root_permitted:
-        print("Running Wine as root is highly discouraged. Use -f|--force-root if you must run as root. See https://wiki.winehq.org/FAQ#Should_I_run_Wine_as_root.3F", file=sys.stderr)  # noqa: E501
+        print("Running Wine/winetricks as root is highly discouraged. Use -f|--force-root if you must run as root. See https://wiki.winehq.org/FAQ#Should_I_run_Wine_as_root.3F", file=sys.stderr)  # noqa: E501
         sys.exit(1)
 
     # Print terminal banner

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -191,6 +191,10 @@ def get_parser():
             '; WARNING: wine will not accept user input!'
         ),
     )
+    cmd.add_argument(
+        '--winetricks', nargs='*',
+        help="run winetricks command",
+    )
     return parser
 
 
@@ -278,11 +282,12 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
         'update_self',
         'update_latest_appimage',
         'wine',
+        'winetricks',
     ]
 
     run_action = None
     for arg in actions:
-        if getattr(args, arg):
+        if getattr(args, arg) or getattr(args, arg) == []:
             if arg == "set_appimage":
                 ephemeral_config.wine_appimage_path = getattr(args, arg)[0]
                 if not utils.file_exists(ephemeral_config.wine_appimage_path):
@@ -293,7 +298,7 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
                     raise argparse.ArgumentTypeError(e)
             # Re-use this variable for either wine or winetricks execution
             elif arg == 'wine' or arg == 'winetricks':
-                ephemeral_config.wine_args = getattr(args, 'wine')
+                ephemeral_config.wine_args = getattr(args, arg)
             run_action = cli_operation(arg)
             break
     if getattr(args, "install_app"):

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -593,12 +593,17 @@ def query_packages(package_manager: PackageManager, packages, mode="install") ->
                     logging.debug(f"'{p}' installed: {line}")
                     status[p] = "Installed"
                     break
-                elif package_manager.query[0] == 'zypper':
+                elif package_manager.query[0] == 'zypper' and mode == "install":
                     # This might be an issue for all OS' however at least on zypper when
                     # the "fuse3" package is installed, it thinks the fuse package is
                     # installed. Solve this by adding whitespace to the startswith
                     package_line_start += " "
-                    if line.strip().startswith(package_line_start) and mode == "install":  # noqa: E501
+                    # zypper also has two (known) possible prefixes 'i  | '
+                    # as set in query_prefix and 'i+ | '
+                    if (
+                        line.strip().startswith(package_line_start)
+                        or line.strip().startswith(f"i+ | {p} ")
+                    ):  # noqa: E501
                         logging.debug(f"'{p}' installed: {line}")
                         status[p] = "Installed"
                         break

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional, Tuple
 from collections.abc import MutableMapping
+import zipfile
 import distro
 import logging
 import os
@@ -12,7 +14,7 @@ import subprocess
 import sys
 import time
 
-from ou_dedetai import constants
+from ou_dedetai import constants, network
 from ou_dedetai.app import App
 
 
@@ -397,8 +399,6 @@ def get_package_manager() -> PackageManager | None:
     os_name = distro.id()
     logging.debug(f"{os_name=}; {major_ver=}")
     # Check for package manager and associated packages.
-    # NOTE: cabextract and sed are included in the appimage, so they are not
-    # included as system dependencies.
 
     install_command: list[str]
     download_command: list[str]
@@ -418,6 +418,7 @@ def get_package_manager() -> PackageManager | None:
         packages = (
             "libfuse2 "  # appimages
             "binutils wget winbind "  # wine
+            "p7zip-full cabextract " # winetricks
         )
         # NOTE: Package names changed together for Ubuntu 24+, Debian 13+, and
         # derivatives. This does not include an exhaustive list of distros that
@@ -455,6 +456,7 @@ def get_package_manager() -> PackageManager | None:
         packages = (
             "fuse fuse-libs "  # appimages
             "mod_auth_ntlm_winbind samba-winbind samba-winbind-clients "  # wine  # noqa: E501
+            "cabextract " # winetricks
         )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('zypper') is not None:  # manjaro
@@ -467,6 +469,7 @@ def get_package_manager() -> PackageManager | None:
             "fuse2 "  # appimages
             "samba wget "  # wine
             "curl gawk grep "  # other
+            "7zip cabextract "  # winetricks
         )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('apk') is not None:  # alpine
@@ -480,6 +483,7 @@ def get_package_manager() -> PackageManager | None:
             "gcompat "  # musl to glibc
             #"fuse-common fuse fuse3 "  # appimages
             "wget curl "  # network
+            "7zip cabextract " # winetricks
             "samba sed grep gawk bash bash-completion "  # other
         )
         incompatible_packages = ""  # appimagelauncher handled separately
@@ -493,6 +497,7 @@ def get_package_manager() -> PackageManager | None:
             "fuse2 "  # appimages
             "samba wget "  # wine
             "curl gawk grep "  # other
+            "p7zip cabextract "  # winetricks (this will likely rename to 7zip shortly)
         )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('pacman') is not None:  # arch, steamOS
@@ -502,12 +507,13 @@ def get_package_manager() -> PackageManager | None:
         query_command =  ["pacman", "-Q"]
         query_prefix = ''
         if os_name == "steamos":  # steamOS
-            packages = "patch wget sed grep gawk cabextract samba bc libxml2 curl print-manager system-config-printer cups-filters nss-mdns foomatic-db-engine foomatic-db-ppds foomatic-db-nonfree-ppds ghostscript glibc samba extra-rel/apparmor core-rel/libcurl-gnutls appmenu-gtk-module lib32-libjpeg-turbo qt5-virtualkeyboard wine-staging giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse libgpg-error lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo sqlite lib32-sqlite libxcomposite lib32-libxcomposite libxinerama lib32-libgcrypt libgcrypt lib32-libxinerama ncurses lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader"  # noqa: E501
+            packages = "patch wget sed grep gawk p7zip cabextract samba bc libxml2 curl print-manager system-config-printer cups-filters nss-mdns foomatic-db-engine foomatic-db-ppds foomatic-db-nonfree-ppds ghostscript glibc samba extra-rel/apparmor core-rel/libcurl-gnutls appmenu-gtk-module lib32-libjpeg-turbo qt5-virtualkeyboard wine-staging giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse libgpg-error lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo sqlite lib32-sqlite libxcomposite lib32-libxcomposite libxinerama lib32-libgcrypt libgcrypt lib32-libxinerama ncurses lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader"  # noqa: E501
         else:  # arch
             # logos_10_packages = "patch wget sed grep cabextract samba glibc samba apparmor libcurl-gnutls appmenu-gtk-module lib32-libjpeg-turbo wine giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse libgpg-error lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo sqlite lib32-sqlite libxcomposite lib32-libxcomposite libxinerama lib32-libgcrypt libgcrypt lib32-libxinerama ncurses lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader"  # noqa: E501
             packages = (
                 "fuse2 "  # appimages
                 "binutils libwbclient samba wget "  # wine
+                "p7zip cabextract " # winetricks (p7zip used to be called pzip)
                 "openjpeg2 libxcomposite libxinerama "  # display
                 "ocl-icd vulkan-icd-loader "  # hardware
                 "alsa-plugins gst-plugins-base-libs libpulse openal "  # audio
@@ -710,15 +716,15 @@ def postinstall_dependencies_steamos(superuser_command: str):
     return command
 
 
-def postinstall_dependencies_alpine(superuser_command: str):
-    user = os.getlogin()
-    command = [
+def postinstall_dependencies_alpine(superuser_command: str) -> list[str]:
+    # user = os.getlogin()
+    command: list[str] = [
         #superuser_command, "modprobe ", "fuse ", "&& ",
-        #superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-update add fuse boot ", "&& ",
+        #superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-update add fuse boot ", "&& ", #noqa: E501
         #superuser_command, "sed ", "-i ", "'s/#user_allow_other/user_allow_other/g' ", "/etc/fuse.conf ", "&& ", #noqa: E501
         #superuser_command, "addgroup ", "fuse ", "&& ",
         #superuser_command, "adduser ", f"{user} ", "fuse ", "&& ",
-        #superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-service fuse restart ", "&& ",
+        #superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-service fuse restart ", "&& ", #noqa: E501
     ]
     return command
 
@@ -872,6 +878,53 @@ def install_dependencies(app: App, target_version=10):  # noqa: E501
         else:
             logging.error("Please reboot then launch the installer again.")
             sys.exit(1)
+
+
+def ensure_winetricks(
+    app: App,
+    version=constants.WINETRICKS_VERSION,
+    status_messages: bool = True
+):
+    winetricks_path = Path(app.conf.installer_binary_dir) / "winetricks"
+
+    if winetricks_path.exists():
+        # No need to do anything
+        return
+
+    # Symlink if using an appimage
+    if (
+        app.conf.wine_binary_code in ["Recommended", "AppImage"]
+        and app.conf.wine_appimage_path is not None
+    ):
+        winetricks_path.symlink_to(app.conf.wine_appimage_path)
+        logging.debug("Winetricks symlinked to appimage.")
+        return
+
+    # Otherwise download
+    if status_messages:
+        app.status(f"Installing winetricks v{version}…")
+    base_url = "https://codeload.github.com/Winetricks/winetricks/zip/refs/tags"  # noqa: E501
+    zip_name = f"{version}.zip"
+    network.logos_reuse_download(
+        f"{base_url}/{version}",
+        zip_name,
+        app.conf.download_dir,
+        app=app,
+        status_messages=status_messages
+    )
+    wtzip = f"{app.conf.download_dir}/{zip_name}"
+    logging.debug(f"Extracting winetricks script to {winetricks_path}…")
+    with zipfile.ZipFile(wtzip) as z:
+        for zi in z.infolist():
+            if zi.is_dir():
+                continue
+            zi.filename = Path(zi.filename).name
+            if zi.filename == 'winetricks':
+                # XXX: ensure this works and doesn't create a directory
+                z.extract(zi, path=str(winetricks_path))
+                break
+    os.chmod(winetricks_path, 0o755)
+    logging.debug("Winetricks installed.")
 
 
 def check_incompatibilities(app: App):

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -476,7 +476,7 @@ def get_package_manager() -> PackageManager | None:
         install_command = ["apk", "--no-interactive", "add"]  # noqa: E501
         download_command = ["apk", "--no-interactive", "fetch"]  # noqa: E501
         remove_command = ["apk", "--no-interactive", "del"]  # noqa: E501
-        query_command = ["apk", "list", "-i"]
+        query_command = ["apk", "list", "-I"]
         query_prefix = ''
         packages = (
             "bash bash-completion "  # bash support

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -920,8 +920,7 @@ def ensure_winetricks(
                 continue
             zi.filename = Path(zi.filename).name
             if zi.filename == 'winetricks':
-                # XXX: ensure this works and doesn't create a directory
-                z.extract(zi, path=str(winetricks_path))
+                z.extract(zi, path=str(winetricks_path.parent))
                 break
     os.chmod(winetricks_path, 0o755)
     logging.debug("Winetricks installed.")

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -466,7 +466,7 @@ def get_package_manager() -> PackageManager | None:
         query_command =  ["zypper", "se", "-si"]
         query_prefix = 'i  | '
         packages = (
-            "fuse2 "  # appimages
+            "fuse "  # appimages
             "samba wget "  # wine
             "curl gawk grep "  # other
             "7zip cabextract "  # winetricks

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -459,7 +459,7 @@ def get_package_manager() -> PackageManager | None:
             "cabextract " # winetricks
         )
         incompatible_packages = ""  # appimagelauncher handled separately
-    elif shutil.which('zypper') is not None:  # manjaro
+    elif shutil.which('zypper') is not None:  # OpenSUSE
         install_command = ["zypper", "--non-interactive", "install"]  # noqa: E501
         download_command = ["zypper", "download"]  # noqa: E501
         remove_command = ["zypper", "--non-interactive", "remove"]  # noqa: E501
@@ -895,6 +895,7 @@ def ensure_winetricks(
     if (
         app.conf.wine_binary_code in ["Recommended", "AppImage"]
         and app.conf.wine_appimage_path is not None
+        and app.conf.wine_appimage_path.exists()
     ):
         winetricks_path.symlink_to(app.conf.wine_appimage_path)
         logging.debug("Winetricks symlinked to appimage.")

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -464,6 +464,7 @@ def get_package_manager() -> PackageManager | None:
         download_command = ["zypper", "download"]  # noqa: E501
         remove_command = ["zypper", "--non-interactive", "remove"]  # noqa: E501
         query_command =  ["zypper", "se", "-si"]
+        # This could also be a 'i+ | '
         query_prefix = 'i  | '
         packages = (
             "fuse "  # appimages
@@ -592,6 +593,15 @@ def query_packages(package_manager: PackageManager, packages, mode="install") ->
                     logging.debug(f"'{p}' installed: {line}")
                     status[p] = "Installed"
                     break
+                elif package_manager.query[0] == 'zypper':
+                    # This might be an issue for all OS' however at least on zypper when
+                    # the "fuse3" package is installed, it thinks the fuse package is
+                    # installed. Solve this by adding whitespace to the startswith
+                    package_line_start += " "
+                    if line.strip().startswith(package_line_start) and mode == "install":  # noqa: E501
+                        logging.debug(f"'{p}' installed: {line}")
+                        status[p] = "Installed"
+                        break
                 elif line.strip().startswith(package_line_start) and mode == "install":  # noqa: E501
                     logging.debug(f"'{p}' installed: {line}")
                     status[p] = "Installed"

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -857,6 +857,9 @@ def install_dependencies(app: App, target_version=10):  # noqa: E501
         f"{app.superuser_command}", 'sh', '-c', '"', *command, '"'
     ]
     command_str = ' '.join(final_command)
+    # FIXME: consider how to tell the user which command we're running.
+    # When we install on the terminal the user doesn't know what they're sudo'ing
+    # logging.info(f"Running command: {command_str}")
 
     if not install_deps_failed:
         try:

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -384,12 +384,10 @@ def run_winetricks(app: App, *args):
     process = run_wine_proc(app.conf.winetricks_binary, app, exe_args=cmd)
     if process is None:
         app.exit("Failed to spawn winetricks")
+    logging.debug(f"Waiting for \"winetricks {' '.join(cmd)}\" To complete")
     process.wait()
-    # XXX: test to ensure this works
     if process.returncode != 0:
-        # XXX: improve warning/exception message
-        logging.warning(f"\"winetricks {' '.join(cmd)}\" Failed!")
-        raise ValueError("Failed to spawn winetricks")
+        app.exit(f"\"winetricks {' '.join(cmd)}\" Failed!")
     logging.info(f"\"winetricks {' '.join(cmd)}\" DONE!")
     wineserver_wait(app)
     logging.debug(f"procs using {app.conf.wine_prefix}:")

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -458,7 +458,7 @@ def install_fonts(app: App):
             # Can hit this case with the debian package ttf-mscorefonts-installer
             logging.debug(f"Found font {f} already installed by other means, no need to install.") #noqa: E501
             continue
-        # XXX: check to make sure we actually hit this case
+        # This case doesn't happen normally, but still good to check.
         # Now we need to check to see if there is a registry key saying it's in Fonts
         # but in reality it's not.
         if registry_key == f"{f}.ttf" and (fonts_dir / f"{f}.ttf").exists():

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -275,6 +275,53 @@ def set_win_version(app: App, exe: str, windows_version: str):
         process.wait()
 
 
+def wine_reg_query(app: App, key_name: str, value_name: str) -> Optional[str]:
+    """Query the registry
+
+    Example command and output:
+
+    ```    
+    $ wine reg query "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts" /v "Arial (TrueType)"
+
+    HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts
+        Arial (TrueType)    REG_SZ    Z:\\usr\\share\\fonts\\truetype\\msttcorefonts\\Arial.ttf
+
+    ```
+    """ #noqa: E501
+    process = run_wine_proc_completed_process(
+        app.conf.wine64_binary,
+        app=app,
+        exe="reg.exe",
+        exe_args=[
+            "query",
+            key_name,
+            "/v",
+            value_name
+        ]
+    )
+    if process.returncode == 1:
+        # Key not found
+        return None
+    elif process.returncode == 0:
+        # Parse output?
+        for line in process.stdout.rstrip().splitlines():
+            # If line is empty that's not what we're looking for
+            if not line:
+                continue
+            if line.strip() == key_name:
+                continue
+            if line.lstrip().startswith(value_name) and "REG_SZ" in line:
+                # This is the line in question
+                return line.split(value_name)[1].split("REG_SZ")[1].strip()
+        logging.warning(f"Failed to parse the registry query: {process.stdout.rstrip()}") #noqa: E501
+        return None
+    else:
+        # Unknown exit code
+        failed = f"Failed to query the registry: Unknown Exit code {process.returncode}"
+        logging.debug(f"{failed}. {process=}")
+        app.exit(f"{failed}: {key_name} {value_name}")
+
+
 def wine_reg_install(app: App, name: str, reg_text: str, wine64_binary: str):
     with tempfile.TemporaryDirectory() as tempdir:
         reg_file = Path(tempdir) / name
@@ -361,12 +408,10 @@ def install_msi(app: App):
     if release_version is not None and utils.check_logos_release_version(release_version, 39, 1): #noqa: E501
         # Define MST path and transform to windows path.
         mst_path = constants.APP_ASSETS_DIR / "LogosStubFailOK.mst"
-        # FIXME: move this to run_wine_proc after types are cleaner
-        transform_winpath = subprocess.run(
-            [wine_exe, 'winepath', '-w', mst_path],
-            env=system.fix_ld_library_path(get_wine_env(app)),
-            capture_output=True,
-            text=True,
+        transform_winpath = run_wine_proc_completed_process(
+            wine_exe,
+            app=app,
+            exe_args=['winepath', '-w', mst_path]
         ).stdout.rstrip()
         exe_args.append(f'TRANSFORMS={transform_winpath}')
         logging.debug(f"TRANSFORMS windows path added: {transform_winpath}")
@@ -404,9 +449,22 @@ def install_fonts(app: App):
     fonts_dir = Path(app.conf.wine_prefix) / "drive_c" / "windows" / "Fonts"
     fonts = ["arial"]
     for i, f in enumerate(fonts):
-        if (fonts_dir / f"{f}.ttf").exists():
+        registry_key = wine_reg_query(
+            app,
+            "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts", #noqa: E501
+            f"{f.capitalize()} (TrueType)"
+        )
+        if registry_key is not None and registry_key != f"{f}.ttf":
+            # Can hit this case with the debian package ttf-mscorefonts-installer
+            logging.debug(f"Found font {f} already installed by other means, no need to install.") #noqa: E501
+            continue
+        # XXX: check to make sure we actually hit this case
+        # Now we need to check to see if there is a registry key saying it's in Fonts
+        # but in reality it's not.
+        if registry_key == f"{f}.ttf" and (fonts_dir / f"{f}.ttf").exists():
             logging.debug(f"Found font {f} already in fonts dir, no need to install.")
             continue
+        # Font isn't installed, continue to install with winetricks.
         app.status(f"Configuring font: {f}…", i / len(fonts)) # noqa: E501
         args = [f]
         run_winetricks(app, *args)
@@ -429,15 +487,40 @@ def get_winecmd_encoding(app: App) -> Optional[str]:
         return None
 
 
+def run_wine_proc_completed_process(
+    winecmd,
+    app: App,
+    exe=None,
+    exe_args=list(),
+    additional_wine_dll_overrides: Optional[str] = None,
+) -> subprocess.CompletedProcess[str]:
+    """Like run_wine_proc but outputs a CompletedProcess
+    and sets it's output to text
+
+    Useful when wanting to parse the output for wine commands
+    """
+    env = get_wine_env(app, additional_wine_dll_overrides)
+    command = [winecmd]
+    if exe is not None:
+        command.append(exe)
+    if exe_args:
+        command.extend(exe_args)
+    return subprocess.run(
+        command,
+        env=system.fix_ld_library_path(env),
+        capture_output=True,
+        text=True,
+    )
+
+
 def run_wine_proc(
     winecmd,
     app: App,
     exe=None,
     exe_args=list(),
     init=False,
-    additional_wine_dll_overrides: Optional[str] = None
+    additional_wine_dll_overrides: Optional[str] = None,
 ) -> Optional[subprocess.Popen[bytes]]:
-    logging.debug("Getting wine environment.")
     env = get_wine_env(app, additional_wine_dll_overrides)
     if isinstance(winecmd, Path):
         winecmd = str(winecmd)
@@ -545,6 +628,7 @@ def get_registry_value(reg_path, name, app: App):
 
 
 def get_wine_env(app: App, additional_wine_dll_overrides: Optional[str]=None) -> dict[str, str]: #noqa: E501
+    logging.debug("Getting wine environment.")
     wine_env = os.environ.copy()
     winepath = Path(app.conf.wine_binary)
     if winepath.name != 'wine64':  # AppImage

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -389,7 +389,6 @@ def run_winetricks(app: App, *args):
     if process.returncode != 0:
         app.exit(f"\"winetricks {' '.join(cmd)}\" Failed!")
     logging.info(f"\"winetricks {' '.join(cmd)}\" DONE!")
-    wineserver_wait(app)
     logging.debug(f"procs using {app.conf.wine_prefix}:")
     for proc in utils.get_procs_using_file(app.conf.wine_prefix):
         logging.debug(f"winetricks proc: {proc=}")


### PR DESCRIPTION
Needed to restore winetricks, however kept as much of non-winetricks as already existed in the code.

Fixes: #335

Removed support for winetricks from the system - no need, the bash script is small

Also checked winetricks exit code (we didn't do this before), to detect when winetricks fails

Restored winetricks binary download, this time using the appimage if found, if not download. Also changed the winetricks version to roughly match appimage for consistency

It should be noted I added cabextract package as a dependency to most OS' that was not there before - unsure how it worked before this.

## Testing overview (OS is debian 12 unless specified) (Logos version is 40 unless otherwise specified):
- [X] Don't download font if file exists
- [x] when the Debian package ttf-mscorefonts-installer is installed, arial is not downloaded 16300d1bf0ddff54d0310699f413b6ad67ce4114
- [X] winetricks failure returns error rather than "DONE"
- [X] Winetricks version is similar across appimage and binary
- [X] winetricks flag works without arguments
- [X] winetricks flag works with argument
- [X] winetricks flag works with arguments
- [x] debian 12 clean install
  - [x] system wine
  - [X] appimage
- [x] arch clean install
  - [x] system wine (wine64 doesn't exist, needed to symlink manually)
  - [x] appimage
- [X] manjaro clean install
  - [X] system wine (needed >4GB of RAM)
  - [x] appimage f8dd588e7be555c92ca5931b8c7d5cca61ba536d
- [x] alpine clean install
  - [x] system wine (10.2r0 sudo apk add wine --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community)
  - ~~[ ] appimage (unsupported)~~ (There is no user friendly indication of this, just appimage is missing from the option to select, and isn't installed by default)
  - [x] Query command functions as intended (didn't before) 16300d1bf0ddff54d0310699f413b6ad67ce4114
- [ ] opensuse leap 15.6 clean install
  - [ ] system wine (needed to install `fuse` package manually and skip deps on f8dd588e7be555c92ca5931b8c7d5cca61ba536d as well as add my hostname to /etc/hosts), still failed to install fonts.
  - [x] appimage
  - [X] installs fuse package successfully a72d2919406a0a9b348c54e715af2a08e86ca47b
- [ ] Ubuntu? Mint?
- [X] TRANSFORMS winepath didn't regress 16300d1bf0ddff54d0310699f413b6ad67ce4114


## Testing details

Clean install (debian 12/manjaro): f8dd588e7be555c92ca5931b8c7d5cca61ba536d
- clean install (--install-app -y --i-agree-to-faithlife-terms)
- logged into logos
- hit continue
- didn't crash
- waited for resources to download
- opened copy bible verses tool
- didn't crash

Font exists: ee02c32d8a5f0ffed21692adf4081413580fcb6d
- clean install
- ran install again
- observed that it didn't run winetricks the second time

Winetricks command without arguments:  0de0648433a417a9e77c7fcc463129990bc92c32
- --winetricks
- launched GUI

Winetricks command with subcommand (arial): 0de0648433a417a9e77c7fcc463129990bc92c32
- --winetricks arial
- successfully installed font

Winetricks command with subcommands: f8dd588e7be555c92ca5931b8c7d5cca61ba536d
- --winetricks fonts list
- wine.log shows font lists

Winetricks symlink missing appimage: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed winetricks symlink
- wine_bin_code of AppImage
- removed arial font
- --winetricks arial
- observed success

Winetricks from appimage doesn't need cabextract on host: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed cabextract
- wine_bin_code of AppImage
- --winetricks arial
- observed success

Winetricks binary missing system wine: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed winetricks
- wine_bin_code of System
- --winetricks arial
- observed winetricks binary downloaded
- observed success

Winetricks binary install right version: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed winetricks
- wine_bin_code of System
- --winetricks --version
- confirmed version matched expected 20250102

Winetricks appimage symlink right version: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed winetricks
- wine_bin_code of AppImage
- --winetricks --version
- confirmed version matched expected 20250102-next

Winetricks failure: 0de0648433a417a9e77c7fcc463129990bc92c32
- removed cabextract from system
- wine_bin_code of System
- removed arial files from wine bottle
- --winetricks arial
- observed Cannot continue because "winetricks -q arial" Failed!

Debian package ttf-mscorefonts-installer: 16300d1bf0ddff54d0310699f413b6ad67ce4114
- Clean install
- Installed debian package ttf-mscorefonts-installer
- Ran Installer
- Used debugger to verify it didn't download font
- Install success
- Confirmed font file wasn't in wine bottle (as it's stored on the system)
- Confirmed no "Configuring font: " output in the logs
- Ran Logos
- Logged in
- Downloaded Resources
- copy bible verse tool works

Confirmed TRANSFORMS winepath still works (as it was refactored): 16300d1bf0ddff54d0310699f413b6ad67ce4114
- Clean install 
- Installed Logos
- Checked wine.log, confirmed TRANSFORMS showed a windows style Z:\ path

OpenSUSE system wine: f8dd588e7be555c92ca5931b8c7d5cca61ba536d
- added localhost.localdomain entry to /etc/hosts
- installed wine 10 via https://en.opensuse.org/Wine#Repositories
- manually installed fuse package (there is a commit after I tested that should fix this step)
- Install using OD
- Fails to install arial
```
2025-02-28T072804: subprocess cmd: '/usr/bin/wine64 wineboot --init'
002c:fixme:actctx:parse_depend_manifests Could not find dependent assembly L"Microsoft.Windows.Common-Controls" (6.0.0.0)
004c:fixme:actctx:parse_depend_manifests Could not find dependent assembly L"Microsoft.Windows.Common-Controls" (6.0.0.0)
0054:fixme:actctx:parse_depend_manifests Could not find dependent assembly L"Microsoft.Windows.Common-Controls" (6.0.0.0)
0054:err:ole:StdMarshalImpl_MarshalInterface Failed to create ifstub, hr 0x80004002
0054:err:ole:CoMarshalInterface Failed to marshal the interface {6d5140c1-7436-11ce-8034-00aa006009fa}, hr 0x80004002
0054:err:ole:apartment_get_local_server_stream Failed: 0x80004002
0054:err:ole:start_rpcss Failed to open RpcSs service
004c:err:ole:StdMarshalImpl_MarshalInterface Failed to create ifstub, hr 0x80004002
004c:err:ole:CoMarshalInterface Failed to marshal the interface {6d5140c1-7436-11ce-8034-00aa006009fa}, hr 0x80004002
004c:err:ole:apartment_get_local_server_stream Failed: 0x80004002
00dc:fixme:msg:pack_message msg 14 (WM_ERASEBKGND) not supported yet
0104:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
wine: configuration in L"/home/user/.local/share/FaithLife-Community/oudedetai/data/wine64_bottle" has been updated.
0104:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
0104:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
0104:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
2025-02-28T072811: subprocess cmd: '/usr/bin/wineserver'
2025-02-28T072811: subprocess cmd: '/usr/bin/wine64 regedit.exe /tmp/tmpxk5a7roe/disable-winemenubuilder.reg'
2025-02-28T072811: subprocess cmd: '/usr/bin/wineserver'
2025-02-28T072811: subprocess cmd: '/usr/bin/wine64 regedit.exe /tmp/tmp9wz6m21n/set-renderer-to-gdi.reg'
2025-02-28T072812: subprocess cmd: '/usr/bin/wineserver'
2025-02-28T072812: subprocess cmd: '/usr/bin/wine64 regedit.exe /tmp/tmp__kkv8no/set-fontsmoothing-to-rgb.reg'
2025-02-28T072812: subprocess cmd: '/usr/bin/wineserver'
2025-02-28T072812: subprocess cmd: '/home/user/.local/share/FaithLife-Community/oudedetai/data/bin/winetricks -q arial'
Executing cd /home/user/.local/share/FaithLife-Community/oudedetai/data/bin
004c:err:ole:start_rpcss Failed to start RpcSs service
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"MountMgr" failed to start: 1053
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"wineusb" failed to start: 1053
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"winebus" failed to start: 1115
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"PlugPlay" failed to start: 1115
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"Eventlog" failed to start: 1115
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"nsiproxy" failed to start: 1115
0144:fixme:service:scmdatabase_autostart_services Auto-start service L"NDIS" failed to start: 1115
002c:err:wineboot:process_run_key Error running cmd L"C:\\windows\\system32\\winemenubuilder.exe -a -r" (126).
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
wine: failed to open "C:\\windows\\syswow64\\regedit.exe": c0000135
 ```
It should be noted, that this command passes when run outside of OD, and the Auto-start error is reproducible after a wineboot with a different wine prefix