### PR TITLE
feat: TUI: add a footer window; split console into header and console windows

### DIFF
--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -250,7 +250,7 @@ class TUI(App):
         self.header_window_ratio = 0.10
         self.console_window_ratio = 0.15
         self.footer_window_ratio = 0.10
-        self.main_window_ratio = 0.55  # Intentionally short his by 10% to avoid hidden lines
+        self.main_window_ratio = 0.55  # Intentionally short this by 10% to avoid hidden lines
 
         self.set_header_window_dimensions()
         self.set_console_window_dimensions()

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -75,7 +75,7 @@ class TUI(App):
 
         # Default height and width to something reasonable so these values are always
         # ints, on each loop these values will be updated to their real values
-        self.window_height_min = 20
+        self.window_height_min = 11
         self.window_height = self.window_width = 80
         self.header_window_height = self.header_window_width = 80
         self.console_window_height = self.console_window_width = 80
@@ -110,7 +110,7 @@ class TUI(App):
         # corresponding @property functions
         self._main_screen: Optional[tui_screen.MenuScreen] = None
         self._active_screen: Optional[tui_screen.Screen] = None
-        self._header: Optional[tui_screen.ConsoleScreen] = None
+        self._header: Optional[tui_screen.HeaderScreen] = None
         self._console: Optional[tui_screen.ConsoleScreen] = None
         self._footer: Optional[tui_screen.FooterScreen] = None
         # End internal property values
@@ -263,7 +263,7 @@ class TUI(App):
         header_window_start = 0
         console_window_start = self.header_window_height
         main_window_start = self.header_window_height + self.console_window_height + 1
-        footer_window_start = self.header_window_height + self.console_window_height + self.main_window_height + 2
+        footer_window_start = self.window_height - self.footer_window_height - 1
 
         self.header_window = curses.newwin(self.header_window_height, curses.COLS, header_window_start, 0)
         self.console_window = curses.newwin(self.console_window_height, curses.COLS, console_window_start, 0)

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -75,30 +75,38 @@ class TUI(App):
 
         # Default height and width to something reasonable so these values are always
         # ints, on each loop these values will be updated to their real values
+        self.window_height_min = 21
         self.window_height = self.window_width = 80
-        self.main_window_height = self.menu_window_height = 80
+        self.header_window_height = self.header_window_width = 80
+        self.main_window_height = self.main_window_width = 80
+        self.footer_window_height = self.footer_window_width = 80
         # Default to a value to allow for int type
-        self.main_window_min: int = 0
-        self.menu_window_min: int = 0
+        self.header_window_height_min: int = 0
+        self.main_window_height_min: int = 0
+        self.footer_window_height_min: int = 0
 
-        self.menu_window_ratio: Optional[float] = None
+        self.header_window_ratio: Optional[float] = None
         self.main_window_ratio: Optional[float] = None
-        self.main_window_ratio = None
+        self.footer_window_ratio: Optional[float] = None
+        self.header_window: Optional[curses.window] = None
         self.main_window: Optional[curses.window] = None
-        self.menu_window: Optional[curses.window] = None
+        self.footer_window: Optional[curses.window] = None
         self.resize_window: Optional[curses.window] = None
 
         # For menu dialogs.
         # a new MenuDialog is created every loop, so we can't store it there.
+        self.options: list = []
         self.current_option: int = 0
         self.current_page: int = 0
         self.total_pages: int = 0
+        self.menu_bottom: int = 0
 
         # Start internal property variables, shouldn't be accessed directly, see their 
         # corresponding @property functions
-        self._menu_screen: Optional[tui_screen.MenuScreen] = None
+        self._main_screen: Optional[tui_screen.MenuScreen] = None
         self._active_screen: Optional[tui_screen.Screen] = None
         self._console: Optional[tui_screen.ConsoleScreen] = None
+        self._footer: Optional[tui_screen.FooterScreen] = None
         # End internal property values
 
         # Lines for the on-screen console log
@@ -129,7 +137,7 @@ class TUI(App):
         self.use_python_dialog = False
 
         logging.debug(f"Use Python Dialog?: {self.use_python_dialog}")
-        self.set_window_dimensions()
+        self.create_windows()
 
         self.config_updated_hooks += [self._config_update_hook]
 
@@ -146,7 +154,7 @@ class TUI(App):
     @property
     def active_screen(self) -> tui_screen.Screen:
         if self._active_screen is None:
-            self._active_screen = self.menu_screen
+            self._active_screen = self.main_screen
             if self._active_screen is None:
                 raise ValueError("Curses hasn't been initialized yet")
         return self._active_screen
@@ -156,9 +164,9 @@ class TUI(App):
         self._active_screen = value
 
     @property
-    def menu_screen(self) -> tui_screen.MenuScreen:
-        if self._menu_screen is None:
-            self._menu_screen = tui_screen.MenuScreen(
+    def main_screen(self) -> tui_screen.MenuScreen:
+        if self._main_screen is None:
+            self._main_screen = tui_screen.MenuScreen(
                 self,
                 0,
                 self.status_q,
@@ -166,7 +174,7 @@ class TUI(App):
                 "Main Menu",
                 self.set_tui_menu_options(),
             )  # noqa: E501
-        return self._menu_screen
+        return self._main_screen
     
     @property
     def console(self) -> tui_screen.ConsoleScreen:
@@ -177,41 +185,71 @@ class TUI(App):
         return self._console
 
     @property
+    def footer(self) -> tui_screen.FooterScreen:
+        if self._footer is None:
+            self._footer = tui_screen.FooterScreen(
+                self, 0, self.status_q, self.status_e, 0
+            )  # noqa: E501
+        return self._footer
+
+    @property
     def recent_console_log(self) -> list[str]:
         """Outputs console log trimmed by the maximum length"""
         return self.console_log[-self.console_log_lines:]
 
-    def set_window_dimensions(self):
-        self.update_tty_dimensions()
-        curses.resizeterm(self.window_height, self.window_width)
-        self.main_window_ratio = 0.25
+    def set_header_window_dimensions(self):
+        self.header_window_ratio = 0.25
         if self.console_log:
             min_console_height = len(tui_curses.wrap_text(self, self.console_log[-1]))
         else:
             min_console_height = 2
-        self.main_window_min = (
-            len(tui_curses.wrap_text(self, self.title))
-            + len(tui_curses.wrap_text(self, self.subtitle))
-            + min_console_height
-        )
-        self.menu_window_ratio = 0.75
-        self.menu_window_min = 3
-        self.main_window_height = max(
-            int(self.window_height * self.main_window_ratio), self.main_window_min
-        )  # noqa: E501#noqa: E501
-        self.menu_window_height = max(
-            self.window_height - self.main_window_height,
-            int(self.window_height * self.menu_window_ratio),
-            self.menu_window_min,
+        self.header_window_height_min = 5
+        # self.header_window_height_min = (
+        #     len(tui_curses.wrap_text(self, self.title))
+        #     + len(tui_curses.wrap_text(self, self.subtitle))
+        #     + min_console_height
+        # )
+        self.header_window_height = max(
+            int(self.window_height * self.header_window_ratio), self.header_window_height_min
         )  # noqa: E501
-        self.console_log_lines = max(self.main_window_height - self.main_window_min, 1)
-        self.options_per_page = max(self.window_height - self.main_window_height - 6, 1)
-        self.main_window = curses.newwin(self.main_window_height, curses.COLS, 0, 0)
-        self.menu_window = curses.newwin(
-            self.menu_window_height, curses.COLS, self.main_window_height + 1, 0
-        )
+
+    def set_footer_window_dimensions(self):
+        self.footer_window_ratio = 0.10
+        self.footer_window_height_min = 3
+        self.footer_window_height = 3
+        #self.footer_window_height = max(
+        #    int(self.window_height * self.footer_window_ratio), self.footer_window_height_min
+        #)
+
+    def set_main_window_dimensions(self):
+        self.main_window_ratio = 0.65
+        self.main_window_height_min = 5
+        self.main_window_height = max(
+            int(self.window_height * self.main_window_ratio), self.main_window_height_min,
+        )  # noqa: E501
+
+    def set_window_dimensions(self):
+        curses.resizeterm(self.window_height, self.window_width)
+
+        self.set_header_window_dimensions()
+        self.set_footer_window_dimensions()
+        self.set_main_window_dimensions()
+
+    def set_windows(self):
+        self.console_log_lines = max(self.header_window_height - self.header_window_height_min, 1)
+        self.options_per_page = max(self.window_height - self.header_window_height - self.main_window_height_min - self.footer_window_height, 1)
+
+        self.header_window = curses.newwin(self.header_window_height, curses.COLS, 0, 0)
+        self.main_window = curses.newwin(self.main_window_height, curses.COLS, self.header_window_height + 1, 0)
+        self.footer_window = curses.newwin(self.footer_window_height, curses.COLS, self.header_window_height + self.main_window_height, 0)
+
         resize_lines = tui_curses.wrap_text(self, "Screen too small.")
         self.resize_window = curses.newwin(len(resize_lines) + 1, curses.COLS, 0, 0)
+
+    def create_windows(self):
+        self.update_tty_dimensions()
+        self.set_window_dimensions()
+        self.set_windows()
 
     @staticmethod
     def set_curses_style():
@@ -231,52 +269,66 @@ class TUI(App):
     def set_curses_color_scheme(self):
         if self.conf.curses_color_scheme == "System":
             self.stdscr.bkgd(" ", curses.color_pair(1))
+            if self.header_window:
+                self.header_window.bkgd(" ", curses.color_pair(1))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(1))
-            if self.menu_window:
-                self.menu_window.bkgd(" ", curses.color_pair(1))
+            if self.footer_window:
+                self.footer_window.bkgd(" ", curses.color_pair(1))
         elif self.conf.curses_color_scheme == "Logos":
             self.stdscr.bkgd(" ", curses.color_pair(4))
+            if self.header_window:
+                self.header_window.bkgd(" ", curses.color_pair(4))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(4))
-            if self.menu_window:
-                self.menu_window.bkgd(" ", curses.color_pair(4))
+            if self.footer_window:
+                self.footer_window.bkgd(" ", curses.color_pair(4))
         elif self.conf.curses_color_scheme == "Light":
             self.stdscr.bkgd(" ", curses.color_pair(6))
+            if self.header_window:
+                self.header_window.bkgd(" ", curses.color_pair(6))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(6))
-            if self.menu_window:
-                self.menu_window.bkgd(" ", curses.color_pair(6))
+            if self.footer_window:
+                self.footer_window.bkgd(" ", curses.color_pair(6))
         elif self.conf.curses_color_scheme == "Dark":
             self.stdscr.bkgd(" ", curses.color_pair(7))
+            if self.header_window:
+                self.header_window.bkgd(" ", curses.color_pair(7))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(7))
-            if self.menu_window:
-                self.menu_window.bkgd(" ", curses.color_pair(7))
+            if self.footer_window:
+                self.footer_window.bkgd(" ", curses.color_pair(7))
 
-    def update_windows(self):
-        if isinstance(self.active_screen, tui_screen.CursesScreen):
-            if self.main_window:
-                self.main_window.erase()
-            if self.menu_window:
-                self.menu_window.erase()
-            self.stdscr.timeout(100)
-            self.console.display()
+    def erase(self):
+        if self.header_window:
+            self.header_window.erase()
+        if self.main_window:
+            self.main_window.erase()
+        if self.footer_window:
+            self.footer_window.erase()
+        if self.resize_window:
+            self.resize_window.erase()
 
     def clear(self):
         self.stdscr.clear()
+        if self.header_window:
+            self.header_window.clear()
         if self.main_window:
             self.main_window.clear()
-        if self.menu_window:
-            self.menu_window.clear()
+        if self.footer_window:
+            self.footer_window.clear()
         if self.resize_window:
             self.resize_window.clear()
 
     def refresh(self):
+        self.stdscr.timeout(100)
+        if self.header_window:
+            self.header_window.noutrefresh()
         if self.main_window:
             self.main_window.noutrefresh()
-        if self.menu_window:
-            self.menu_window.noutrefresh()
+        if self.footer_window:
+            self.footer_window.noutrefresh()
         if self.resize_window:
             self.resize_window.noutrefresh()
         curses.doupdate()
@@ -292,9 +344,9 @@ class TUI(App):
             curses.cbreak()
             self.stdscr.keypad(True)
 
-            # Reset console/menu_screen. They'll be initialized next access
+            # Reset console/main_screen. They'll be initialized next access
             self._console = None
-            self._menu_screen = tui_screen.MenuScreen(
+            self._main_screen = tui_screen.MenuScreen(
                 self,
                 0,
                 self.status_q,
@@ -302,7 +354,8 @@ class TUI(App):
                 "Main Menu",
                 self.set_tui_menu_options(),
             )  # noqa: E501
-            # self.menu_screen = tui_screen.MenuDialog(self, 0, self.status_q, self.status_e, "Main Menu", self.set_tui_menu_options(dialog=True)) #noqa: E501
+            self._footer = None
+            # self.main_screen = tui_screen.MenuDialog(self, 0, self.status_q, self.status_e, "Main Menu", self.set_tui_menu_options(dialog=True)) #noqa: E501
             self.refresh()
         except curses.error as e:
             logging.error(f"Curses error in init_curses: {e}")
@@ -337,7 +390,7 @@ class TUI(App):
         curses.endwin()
 
     def update_main_window_contents(self):
-        self.menu_screen.set_options(self.set_tui_menu_options())
+        self.main_screen.set_options(self.set_tui_menu_options())
 
     # ERR: On a sudden resize, the Curses menu is not properly resized,
     # and we are not currently dynamically passing the menu options based
@@ -349,8 +402,7 @@ class TUI(App):
     def resize_curses(self):
         self.resizing = True
         curses.endwin()
-        self.update_tty_dimensions()
-        self.set_window_dimensions()
+        self.create_windows()
         self.clear()
         self.init_curses()
         self.refresh()
@@ -370,7 +422,7 @@ class TUI(App):
 
     def draw_resize_screen(self):
         self.clear()
-        if self.window_width > 10:
+        if self.window_width > self.window_height_min:
             margin = self.terminal_margin
         else:
             margin = 0
@@ -399,21 +451,24 @@ class TUI(App):
         self.status_q.put(f"{timestamp} {self.console_message}")
         self.report_waiting(f"{self.console_message}")  # noqa: E501
 
-        self.active_screen = self.menu_screen
+        self.active_screen = self.main_screen
         check_resize_last_time = last_time = time.time()
         self.logos.monitor()
 
         while self.is_running:
-            if self.window_height >= 10 and self.window_width >= 35:
+            if self.window_height >= self.window_height_min and self.window_width >= 35:
                 self.terminal_margin = 2
                 if not self.resizing:
-                    self.update_windows()
+                    if isinstance(self.active_screen, tui_screen.CursesScreen):
+                        self.erase()
+                        self.console.display()
+                        self.footer.display()
 
                     self.active_screen.display()
 
                     if self.choice_q.qsize() > 0:
                         self.choice_processor(
-                            self.menu_window,
+                            self.main_window,
                             self.active_screen.screen_id,
                             self.choice_q.get(),
                         )
@@ -422,7 +477,7 @@ class TUI(App):
                                 self.tui_screens.pop()
 
                     if len(self.tui_screens) == 0:
-                        self.active_screen = self.menu_screen
+                        self.active_screen = self.main_screen
                     else:
                         self.active_screen = self.tui_screens[-1]
 
@@ -430,16 +485,16 @@ class TUI(App):
                         run_monitor, last_time = utils.stopwatch(last_time, 2.5)
                         if run_monitor:
                             self.logos.monitor()
-                            self.menu_screen.set_options(self.set_tui_menu_options())
+                            self.main_screen.set_options(self.set_tui_menu_options())
 
                     if isinstance(self.active_screen, tui_screen.CursesScreen):
                         self.refresh()
-            elif self.window_width >= 10:
-                if self.window_width < 10:
+            elif self.window_width >= self.window_height_min:
+                if self.window_width < self.window_height_min:
                     # Avoid drawing errors on very small screens
                     self.terminal_margin = 1
                 self.draw_resize_screen()
-            elif self.window_width < 10:
+            elif self.window_width < self.window_height_min:
                 self.terminal_margin = 0  # Avoid drawing errors on very small screens
             # Check every second to see if the screen resized without our know-how
             # This is done on a timer because curses.is_term_resized takes a fair bit of
@@ -516,9 +571,9 @@ class TUI(App):
     def go_to_main_menu(self):
         self.tui_screens = []
         self.reset_screen()
-        self.menu_screen.choice = "Processing"
+        self.main_screen.choice = "Processing"
         # Reset running state of main menu so it can submit again.
-        self.menu_screen.running = 0
+        self.main_screen.running = 0
         self.choice_q.put("Return to Main Menu")
 
     def main_menu_select(self, choice):
@@ -561,11 +616,11 @@ class TUI(App):
         elif self.conf._raw.faithlife_product and choice == f"Run {self.conf._raw.faithlife_product}": #noqa: E501
             self.reset_screen()
             self.logos.start()
-            self.menu_screen.set_options(self.set_tui_menu_options())
+            self.main_screen.set_options(self.set_tui_menu_options())
         elif self.conf._raw.faithlife_product and choice == f"Stop {self.conf.faithlife_product}": #noqa: E501
             self.reset_screen()
             self.logos.stop()
-            self.menu_screen.set_options(self.set_tui_menu_options())
+            self.main_screen.set_options(self.set_tui_menu_options())
         elif choice == "Run Indexing":
             self.active_screen.running = 0
             self.active_screen.choice = "Processing"
@@ -698,9 +753,9 @@ class TUI(App):
             appimage_filename = choice
         self.conf.wine_appimage_path = Path(appimage_filename)
         utils.set_appimage_symlink(self)
-        if not self.menu_window:
+        if not self.main_window:
             raise ValueError("Curses hasn't been initialized")
-        self.menu_screen.choice = "Processing"
+        self.main_screen.choice = "Processing"
         self.appimage_q.put(str(self.conf.wine_appimage_path))
         self.appimage_e.set()
 
@@ -718,7 +773,7 @@ class TUI(App):
 
     def password_prompt(self, choice):
         if choice:
-            self.menu_screen.choice = "Processing"
+            self.main_screen.choice = "Processing"
             self.password_q.put(choice)
             self.password_e.set()
 
@@ -749,13 +804,13 @@ class TUI(App):
     def switch_screen(self):
         if (
             self.active_screen is not None
-            and self.active_screen != self.menu_screen
+            and self.active_screen != self.main_screen
             and len(self.tui_screens) > 0
         ):  # noqa: E501
             self.tui_screens.pop(0)
-        if self.active_screen == self.menu_screen:
-            self.menu_screen.choice = "Processing"
-            self.menu_screen.running = 0
+        if self.active_screen == self.main_screen:
+            self.main_screen.choice = "Processing"
+            self.main_screen.running = 0
         if isinstance(self.active_screen, tui_screen.CursesScreen):
             self.clear()
 
@@ -1202,8 +1257,8 @@ class TUI(App):
     def update_tty_dimensions(self):
         self.window_height, self.window_width = self.stdscr.getmaxyx()
 
-    def get_menu_window(self):
-        return self.menu_window
+    def get_main_window(self):
+        return self.main_window
 
 
 def control_panel_app(stdscr: curses.window, ephemeral_config: EphemeralConfiguration):

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -212,10 +212,11 @@ class TUI(App):
         return self.console_log[-self.console_log_lines:]
 
     def set_header_window_dimensions(self):
-        self.header_window_height_min = 2
-        self.header_window_height = min(max(
-            int(self.window_height * self.header_window_ratio), self.header_window_height_min
-        ), 4)
+        self.header_window_height_min = 3
+        self.header_window_height = 3
+        # self.header_window_height = min(max(
+        #     int(self.window_height * self.header_window_ratio), self.header_window_height_min
+        # ), 4)
 
     def set_console_window_dimensions(self):
         if self.console_log:

--- a/ou_dedetai/tui_curses.py
+++ b/ou_dedetai/tui_curses.py
@@ -40,7 +40,7 @@ def title(app: App, title_text, title_start_y_adj):
     from ou_dedetai.tui_app import TUI
     if not isinstance(app, TUI):
         raise ValueError("curses MUST be used with the TUI")
-    stdscr = app.main_window
+    stdscr = app.header_window
     if not stdscr:
         raise Exception("Expected main window to be initialized, but it wasn't")
     title_lines = wrap_text(app, title_text)
@@ -58,7 +58,7 @@ def text_centered(app: App, text: str, start_y=0) -> tuple[int, list[str]]:
     from ou_dedetai.tui_app import TUI
     if not isinstance(app, TUI):
         raise ValueError("curses MUST be used with the TUI")
-    stdscr = app.get_menu_window()
+    stdscr = app.get_main_window()
     text_lines = wrap_text(app, text)
     text_start_y = start_y
     text_width = max(len(line) for line in text_lines)
@@ -84,7 +84,7 @@ def confirm(app: App, question_text: str, height=None, width=None):
     from ou_dedetai.tui_app import TUI
     if not isinstance(app, TUI):
         raise ValueError("curses MUST be used with the TUI")
-    stdscr = app.get_menu_window()
+    stdscr = app.get_main_window()
     question_text = question_text + " [Y/n]: "
     question_start_y, question_lines = text_centered(app, question_text)
 
@@ -106,7 +106,7 @@ class CursesDialog:
     def __init__(self, app):
         from ou_dedetai.tui_app import TUI
         self.app: TUI = app
-        self.stdscr: curses.window = self.app.get_menu_window()
+        self.stdscr: curses.window = self.app.get_main_window()
 
     def __str__(self):
         return "Curses Dialog"
@@ -219,7 +219,7 @@ class MenuDialog(CursesDialog):
         self.user_input = "Processing"
         self.submit = False
         self.question_text = question_text
-        self.options = options
+        self.app.options = options
         self.question_start_y = None
         self.question_lines = None
 
@@ -230,18 +230,18 @@ class MenuDialog(CursesDialog):
         self.stdscr.erase()
         # We should be on a menu screen at this point
         if isinstance(self.app.active_screen, tui_screen.MenuScreen):
-            self.app.active_screen.set_options(self.options)
-        self.total_pages = (len(self.options) - 1) // self.app.options_per_page + 1
+            self.app.active_screen.set_options(self.app.options)
+        self.total_pages = (len(self.app.options) - 1) // self.app.options_per_page + 1
         # Default menu_bottom to 0, it should get set to something larger
         menu_bottom = 0
 
         self.question_start_y, self.question_lines = text_centered(self.app, self.question_text) #noqa: E501
         # Display the options, centered
-        options_start_y = self.question_start_y + len(self.question_lines) + 2
+        options_start_y = self.question_start_y + len(self.question_lines) + 1
         for i in range(self.app.options_per_page):
             index = self.app.current_page * self.app.options_per_page + i
-            if index < len(self.options):
-                option = self.options[index]
+            if index < len(self.app.options):
+                option = self.app.options[index]
                 if type(option) is list:
                     option_lines = []
                     wine_binary_code = option[0]
@@ -269,19 +269,17 @@ class MenuDialog(CursesDialog):
                 for j, line in enumerate(option_lines):
                     y = options_start_y + i + j
                     x = max(0, self.app.window_width // 2 - len(line) // 2)
-                    if y < self.app.menu_window_height:
+                    if y < self.app.main_window_height:
                         if index == self.app.current_option:
                             write_line(self.app, self.stdscr, y, x, line, self.app.window_width, curses.A_REVERSE) #noqa: E501
                         else:
                             write_line(self.app, self.stdscr, y, x, line, self.app.window_width) #noqa: E501
-                menu_bottom = y
+                self.app.menu_bottom = y
 
                 if type(option) is list:
                     options_start_y += (len(option_lines))
 
         # Display pagination information
-        page_info = f"Page {self.app.current_page + 1}/{self.total_pages} | Selected Option: {self.app.current_option + 1}/{len(self.options)}" #noqa: E501
-        write_line(self.app, self.stdscr, max(menu_bottom, self.app.menu_window_height) - 3, 2, page_info, self.app.window_width, curses.A_BOLD) #noqa: E501
 
     def do_menu_up(self):
         if self.app.current_option == self.app.current_page * self.app.options_per_page and self.app.current_page > 0: #noqa: E501
@@ -312,15 +310,15 @@ class MenuDialog(CursesDialog):
         if len(self.app.tui_screens) > 0:
             self.stdscr = self.app.tui_screens[-1].get_stdscr()
         else:
-            self.stdscr = self.app.menu_screen.get_stdscr()
+            self.stdscr = self.app.main_screen.get_stdscr()
         key = self.stdscr.getch()
 
         try:
             if key == -1:  # If key not found, keep processing.
                 pass
-            elif key == curses.KEY_UP or key == 259:  # Up arrow
+            elif key == curses.KEY_UP or key == 259 or key == curses.KEY_LEFT or key == 260:  # Up arrow
                 self.do_menu_up()
-            elif key == curses.KEY_DOWN or key == 258:  # Down arrow
+            elif key == curses.KEY_DOWN or key == 258 or key == curses.KEY_RIGHT or key == 261:  # Down arrow
                 self.do_menu_down()
             elif key == 27:
                 # Sometimes the up/down arrow key is represented by a series of 3 keys.
@@ -332,7 +330,7 @@ class MenuDialog(CursesDialog):
                     elif final_key == 66:
                         self.do_menu_down()
             elif key == ord('\n') or key == 10:  # Enter key
-                self.user_input = self.options[self.app.current_option]
+                self.user_input = self.app.options[self.app.current_option]
             elif key == ord('\x1b'):
                 signal.signal(signal.SIGINT, self.app.end)
         except KeyboardInterrupt:
@@ -348,5 +346,5 @@ class MenuDialog(CursesDialog):
         return self.user_input
 
     def set_options(self, new_options):
-        self.options = new_options
+        self.app.options = new_options
         self.app.menu_options = new_options

--- a/ou_dedetai/tui_curses.py
+++ b/ou_dedetai/tui_curses.py
@@ -36,11 +36,10 @@ def write_line(app: App, stdscr: curses.window, start_y, start_x, text, char_lim
         pass
 
 
-def title(app: App, title_text, title_start_y_adj):
+def title(app: App, stdscr: curses.window, title_text, title_start_y_adj):
     from ou_dedetai.tui_app import TUI
     if not isinstance(app, TUI):
         raise ValueError("curses MUST be used with the TUI")
-    stdscr = app.header_window
     if not stdscr:
         raise Exception("Expected main window to be initialized, but it wasn't")
     title_lines = wrap_text(app, title_text)
@@ -54,11 +53,10 @@ def title(app: App, title_text, title_start_y_adj):
     return last_index
 
 
-def text_centered(app: App, text: str, start_y=0) -> tuple[int, list[str]]:
+def text_centered(app: App, stdscr: curses.window, text: str, start_y=0) -> tuple[int, list[str]]:
     from ou_dedetai.tui_app import TUI
     if not isinstance(app, TUI):
         raise ValueError("curses MUST be used with the TUI")
-    stdscr = app.get_main_window()
     text_lines = wrap_text(app, text)
     text_start_y = start_y
     text_width = max(len(line) for line in text_lines)
@@ -71,10 +69,10 @@ def text_centered(app: App, text: str, start_y=0) -> tuple[int, list[str]]:
     return text_start_y, text_lines
 
 
-def spinner(app: App, index: int, start_y: int = 0):
+def spinner(app: App, stdscr: curses.window, index: int, start_y: int = 0):
     spinner_chars = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"]
     i = index
-    text_centered(app, spinner_chars[i], start_y)
+    text_centered(app, stdscr, spinner_chars[i], start_y)
     i = (i + 1) % len(spinner_chars)
     return i
 
@@ -129,7 +127,7 @@ class UserInputDialog(CursesDialog):
         self.user_input = default_text
         self.submit = False
 
-        self.question_start_y, self.question_lines = text_centered(self.app, self.question_text) #noqa: E501
+        self.question_start_y, self.question_lines = text_centered(self.app, self.stdscr, self.question_text) #noqa: E501
 
 
     def __str__(self):
@@ -139,7 +137,7 @@ class UserInputDialog(CursesDialog):
         curses.echo()
         curses.curs_set(1)
         self.stdscr.clear()
-        self.question_start_y, self.question_lines = text_centered(self.app, self.question_text) #noqa: E501
+        self.question_start_y, self.question_lines = text_centered(self.app, self.stdscr, self.question_text) #noqa: E501
         self.input()
         curses.curs_set(0)
         curses.noecho()
@@ -231,11 +229,9 @@ class MenuDialog(CursesDialog):
         # We should be on a menu screen at this point
         if isinstance(self.app.active_screen, tui_screen.MenuScreen):
             self.app.active_screen.set_options(self.app.options)
-        self.total_pages = (len(self.app.options) - 1) // self.app.options_per_page + 1
-        # Default menu_bottom to 0, it should get set to something larger
-        menu_bottom = 0
+        self.app.total_pages = (len(self.app.options) - 1) // self.app.options_per_page + 1
 
-        self.question_start_y, self.question_lines = text_centered(self.app, self.question_text) #noqa: E501
+        self.question_start_y, self.question_lines = text_centered(self.app, self.stdscr, self.question_text) #noqa: E501
         # Display the options, centered
         options_start_y = self.question_start_y + len(self.question_lines) + 1
         for i in range(self.app.options_per_page):
@@ -279,24 +275,22 @@ class MenuDialog(CursesDialog):
                 if type(option) is list:
                     options_start_y += (len(option_lines))
 
-        # Display pagination information
-
     def do_menu_up(self):
         if self.app.current_option == self.app.current_page * self.app.options_per_page and self.app.current_page > 0: #noqa: E501
             # Move to the previous page
             self.app.current_page -= 1
             self.app.current_option = min(len(self.app.menu_options) - 1, (self.app.current_page + 1) * self.app.options_per_page - 1) #noqa: E501
         elif self.app.current_option == 0:
-            if self.total_pages == 1:
+            if self.app.total_pages == 1:
                 self.app.current_option = len(self.app.menu_options) - 1
             else:
-                self.app.current_page = self.total_pages - 1
+                self.app.current_page = self.app.total_pages - 1
                 self.app.current_option = len(self.app.menu_options) - 1
         else:
             self.app.current_option = max(0, self.app.current_option - 1)
 
     def do_menu_down(self):
-        if self.app.current_option == (self.app.current_page + 1) * self.app.options_per_page - 1 and self.app.current_page < self.total_pages - 1: #noqa: E501
+        if self.app.current_option == (self.app.current_page + 1) * self.app.options_per_page - 1 and self.app.current_page < self.app.total_pages - 1: #noqa: E501
             # Move to the next page
             self.app.current_page += 1
             self.app.current_option = min(len(self.app.menu_options) - 1, self.app.current_page * self.app.options_per_page) #noqa: E501

--- a/ou_dedetai/tui_screen.py
+++ b/ou_dedetai/tui_screen.py
@@ -129,7 +129,6 @@ class FooterScreen(CursesScreen):
         self.stdscr.erase()
 
         footer_text = "By the FaithLife Community"
-        footer_hr = "---"
 
         if isinstance(self.app.active_screen, MenuScreen):
             page_info = f"Page {self.app.current_page + 1}/{self.app.total_pages} | Selected Option: {self.app.current_option + 1}/{len(self.app.options)}" #noqa: E501

--- a/ou_dedetai/tui_screen.py
+++ b/ou_dedetai/tui_screen.py
@@ -1,9 +1,9 @@
 import curses
 import logging
 import time
+from queue import Queue
+from threading import Event
 from typing import Optional
-
-from ou_dedetai.app import App
 
 from . import installer
 from . import system
@@ -11,9 +11,10 @@ from . import tui_curses
 if system.have_dep("dialog"):
     from . import tui_dialog
 
+from ou_dedetai.app import App
 
 class Screen:
-    def __init__(self, app: App, screen_id, queue, event):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event):
         from ou_dedetai.tui_app import TUI
         if not isinstance(app, TUI):
             raise ValueError("Cannot start TUI screen with non-TUI app")
@@ -64,7 +65,7 @@ class DialogScreen(Screen):
 
 
 class ConsoleScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, start_y):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, start_y: int):
         super().__init__(app, screen_id, queue, event)
         self.stdscr: Optional[curses.window] = self.app.console_window
         self.start_y = start_y
@@ -91,7 +92,7 @@ class ConsoleScreen(CursesScreen):
 
 
 class HeaderScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, title, subtitle, title_start_y):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, title: str, subtitle: str, title_start_y: int):
         super().__init__(app, screen_id, queue, event)
         self.stdscr: Optional[curses.window] = self.app.header_window
         self.title = title
@@ -114,7 +115,7 @@ class HeaderScreen(CursesScreen):
 
 
 class FooterScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, start_y):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, start_y: int):
         super().__init__(app, screen_id, queue, event)
         self.stdscr: Optional[curses.window] = self.app.footer_window
         self.start_y = start_y
@@ -140,7 +141,7 @@ class FooterScreen(CursesScreen):
 
 
 class MenuScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, question, options, height=None, width=None, menu_height=8): #noqa: E501
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, question: str, options: list, height: int=None, width: int=None, menu_height: int=8): #noqa: E501
         super().__init__(app, screen_id, queue, event)
         self.stdscr = self.app.get_main_window()
         self.question = question
@@ -176,7 +177,7 @@ class MenuScreen(CursesScreen):
 
 
 class ConfirmScreen(MenuScreen):
-    def __init__(self, app, screen_id, queue, event, question, no_text, secondary, options=["Yes", "No"]): #noqa: E501
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, question: str, no_text: str, secondary: str, options: list=["Yes", "No"]): #noqa: E501
         super().__init__(app, screen_id, queue, event, question, options,
                          height=None, width=None, menu_height=8)
         self.no_text = no_text
@@ -204,7 +205,7 @@ class ConfirmScreen(MenuScreen):
 
 
 class InputScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, question: str, default):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, question: str, default: str):
         super().__init__(app, screen_id, queue, event)
         self.stdscr = self.app.get_main_window()
         self.question = question
@@ -237,7 +238,7 @@ class InputScreen(CursesScreen):
 
 
 class PasswordScreen(InputScreen):
-    def __init__(self, app, screen_id, queue, event, question, default):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, question: str, default: str):
         super().__init__(app, screen_id, queue, event, question, default)
         # Update type for type linting
         from ou_dedetai.tui_app import TUI
@@ -265,7 +266,7 @@ class PasswordScreen(InputScreen):
 
 
 class TextScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, text, wait):
+    def __init__(self, app: App, screen_id: int, queue: Queue, event: Event, text: str, wait: bool):
         super().__init__(app, screen_id, queue, event)
         self.stdscr = self.app.get_main_window()
         self.text = text

--- a/ou_dedetai/tui_screen.py
+++ b/ou_dedetai/tui_screen.py
@@ -108,7 +108,8 @@ class HeaderScreen(CursesScreen):
                             "Please report this incident to the developers")
         self.stdscr.erase()
         subtitle_start = tui_curses.title(self.app, self.stdscr, self.title, self.title_start_y)
-        tui_curses.title(self.app, self.stdscr, self.subtitle, subtitle_start + 1)
+        if self.app.window_width > 37:
+            tui_curses.title(self.app, self.stdscr, self.subtitle, subtitle_start + 1)
 
         self.stdscr.noutrefresh()
         curses.doupdate()

--- a/ou_dedetai/tui_screen.py
+++ b/ou_dedetai/tui_screen.py
@@ -66,7 +66,7 @@ class DialogScreen(Screen):
 class ConsoleScreen(CursesScreen):
     def __init__(self, app, screen_id, queue, event, title, subtitle, title_start_y):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr: Optional[curses.window] = self.app.main_window
+        self.stdscr: Optional[curses.window] = self.app.header_window
         self.title = title
         self.subtitle = subtitle
         self.title_start_y = title_start_y
@@ -97,10 +97,37 @@ class ConsoleScreen(CursesScreen):
         curses.doupdate()
 
 
+class FooterScreen(CursesScreen):
+    def __init__(self, app, screen_id, queue, event, start_y):
+        super().__init__(app, screen_id, queue, event)
+        self.stdscr: Optional[curses.window] = self.app.footer_window
+        self.start_y = start_y
+
+    def __str__(self):
+        return "Curses Footer Screen"
+
+    def display(self):
+        if self.stdscr is None:
+            raise Exception("stdscr should be set at this point in the console screen."
+                            "Please report this incident to the developers")
+        self.stdscr.erase()
+
+        footer_text = "By the FaithLife Community"
+        footer_hr = "---"
+
+        if isinstance(self.app.active_screen, MenuScreen):
+            page_info = f"Page {self.app.current_page + 1}/{self.app.total_pages} | Selected Option: {self.app.current_option + 1}/{len(self.app.options)}" #noqa: E501
+            tui_curses.write_line(self.app, self.stdscr, self.start_y, 2, page_info, self.app.window_width, curses.A_BOLD) #noqa: E501
+        tui_curses.write_line(self.app, self.stdscr, self.app.footer_window_height - 1, self.app.terminal_margin, footer_text, self.app.window_width - (self.app.terminal_margin * 2)) #noqa: E501
+
+        self.stdscr.noutrefresh()
+        curses.doupdate()
+
+
 class MenuScreen(CursesScreen):
     def __init__(self, app, screen_id, queue, event, question, options, height=None, width=None, menu_height=8): #noqa: E501
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.options = options
         self.height = height
@@ -164,7 +191,7 @@ class ConfirmScreen(MenuScreen):
 class InputScreen(CursesScreen):
     def __init__(self, app, screen_id, queue, event, question: str, default):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.default = default
         self.dialog = tui_curses.UserInputDialog(
@@ -225,7 +252,7 @@ class PasswordScreen(InputScreen):
 class TextScreen(CursesScreen):
     def __init__(self, app, screen_id, queue, event, text, wait):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.text = text
         self.wait = wait
         self.spinner_index = 0
@@ -252,7 +279,7 @@ class TextScreen(CursesScreen):
 class MenuDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, question, options, height=None, width=None, menu_height=8): #noqa: E501
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.options = options
         self.height = height
@@ -280,7 +307,7 @@ class MenuDialog(DialogScreen):
 class InputDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, question, default):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.default = default
 
@@ -322,7 +349,7 @@ class PasswordDialog(InputDialog):
 class ConfirmDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, question, no_text, secondary, yes_label="Yes", no_label="No"): #noqa: E501
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.no_text = no_text
         self.secondary = secondary
@@ -352,7 +379,7 @@ class TextDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, text, wait=False, percent=None, 
                  height=None, width=None, title=None, backtitle=None, colors=True):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.text = text
         self.percent = percent
         self.wait = wait
@@ -405,7 +432,7 @@ class TaskListDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, text, elements, percent,
                  height=None, width=None, title=None, backtitle=None, colors=True):
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.text = text
         self.elements = elements if elements is not None else {}
         self.percent = percent
@@ -452,7 +479,7 @@ class TaskListDialog(DialogScreen):
 class BuildListDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, question, options, list_height=None, height=None, width=None): #noqa: E501
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.options = options
         self.height = height
@@ -480,7 +507,7 @@ class BuildListDialog(DialogScreen):
 class CheckListDialog(DialogScreen):
     def __init__(self, app, screen_id, queue, event, question, options, list_height=None, height=None, width=None): #noqa: E501
         super().__init__(app, screen_id, queue, event)
-        self.stdscr = self.app.get_menu_window()
+        self.stdscr = self.app.get_main_window()
         self.question = question
         self.options = options
         self.height = height


### PR DESCRIPTION
Fixes #342.

Besides declaring new variables for each of the new windows, this also renames the console window to header and the menu window to main. As part of this, some of the functions needed to have the appropriate screen passed to them rather than calling that screen from the App. I tried a branch where I removed the App dependency from tui_screen.py and tui_curses.py but I was unable to get the drawing correct. I believe I need to rework that branch as I think there is some bad tracking with the new variables.

I modularize some of the bigger functions and simplify some of the functions where I could implement logic. I also swap some of the static numbers for their appropriate variable.

I also added the ability to navigate TUI menus with left and right arrow keys. What sparked the add was that when the TUI is small enough to only display one option in the menu, up and down no longer make sense. Now the user can use either set of keys.

There is more refactoring that can be done, such as passing the footer contents to the footer screen rather than declaring them within the footer. Those were things I had tackled in the refactor away from an app dependency. I'll look at adding them in again in the future in smaller PRs.