### PR TITLE
fix: cleanup logos 9

### DIFF
--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -88,7 +88,7 @@ LOGOS_WHITE = '#FCFCFC'
 PID_FILE = f'/tmp/{BINARY_NAME}.pid'
 
 FAITHLIFE_PRODUCTS = ["Logos", "Verbum"]
-FAITHLIFE_PRODUCT_VERSIONS = ["10", "9"]
+FAITHLIFE_PRODUCT_VERSIONS = ["10"] # This used to include 9
 
 SUPPORT_MESSAGE = f"If you need help, please consult:\n{WIKI_LINK}\nIf that doesn't answer your question, please send the following files {DEFAULT_CONFIG_PATH}, {DEFAULT_APP_WINE_LOG_PATH} and {DEFAULT_APP_LOG_PATH} to one of the following group chats:\nTelegram: {TELEGRAM_LINK}\nMatrix: {MATRIX_LINK}"  # noqa: E501
 

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -79,7 +79,7 @@ class InstallerGui(Frame):
         self.version_dropdown.state(['readonly'])
         #TODO: Remove this dropdown
         self.version_dropdown['values'] = ('10')
-        self.versionvar.set(self.version_dropdown['values'][1])
+        self.versionvar.set(self.version_dropdown['values'][0])
         if app.conf._raw.faithlife_product_version in self.version_dropdown['values']:
             self.version_dropdown.set(app.conf._raw.faithlife_product_version)
 


### PR DESCRIPTION
GUI advanced install was crashing (as there wasn't a 1st index anymore)

Constant isn't use anywhere