### PR TITLE
fix: allow user to return to main menu during install

### DIFF
--- a/ou_dedetai/app.py
+++ b/ou_dedetai/app.py
@@ -14,6 +14,10 @@ from ou_dedetai.constants import (
 )
 
 
+class UserExitedFromAsk(Exception):
+    """Exception thrown when the user hit cancel in an ask dialog"""
+
+
 class App(abc.ABC):
     # FIXME: consider weighting install steps. Different steps take different lengths
     installer_step_count: int = 0
@@ -104,6 +108,8 @@ class App(abc.ABC):
             passed_options = options + [self._exit_option]
 
         answer = self._ask(question, passed_options)
+        if answer is None or answer == self._exit_option:
+            raise UserExitedFromAsk
         while answer is None or validate_result(answer, options) is None:
             invalid_response = "That response is not valid, please try again."
             new_question = f"{invalid_response}\n{question}"
@@ -115,12 +121,6 @@ class App(abc.ABC):
                 # Huh? coding error, this should have been checked earlier
                 logging.critical("An invalid response slipped by, please report this incident to the developers") #noqa: E501
                 self.exit("Failed to get a valid value from user")
-
-        if answer == self._exit_option:
-            answer = None
-        
-        if answer is None:
-            self.exit("Failed to get a valid value from user")
 
         return answer
 

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -674,7 +674,7 @@ class Config:
         return self._ask_if_not_found("faithlife_product_release", question, options)
 
     @faithlife_product_release.setter
-    def faithlife_product_release(self, value: str):
+    def faithlife_product_release(self, value: Optional[str]):
         if self._raw.faithlife_product_release != value:
             self._raw.faithlife_product_release = value
             # Reset dependents

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -18,7 +18,7 @@ from tkinter import filedialog as fd
 from tkinter.ttk import Style
 from typing import Callable, Optional
 
-from ou_dedetai.app import App
+from ou_dedetai.app import App, UserExitedFromAsk
 from ou_dedetai.constants import PROMPT_OPTION_DIRECTORY, PROMPT_OPTION_FILE
 from ou_dedetai.config import EphemeralConfiguration
 
@@ -476,9 +476,16 @@ class ControlWindow(GuiApp):
         
         Fallback to defaults if we don't know a response"""
         def _install():
-            installer.install(self)
-            # Enable the run button
-            self.gui.app_button.state(['!disabled'])
+            try:
+                self.populate_defaults()
+                installer.install(self)
+            except UserExitedFromAsk:
+                # Ensure that the defaults are properly set back up
+                self.populate_defaults()
+            finally:
+                # Enable the run button
+                self.gui.app_button.state(['!disabled'])
+                self.gui.app_install_advanced.state(['!disabled'])
         # Disable the install buttons
         self.gui.app_button.state(['disabled'])
         self.gui.app_install_advanced.state(['disabled'])

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from ou_dedetai import system
-from ou_dedetai.app import App
+from ou_dedetai.app import App, UserExitedFromAsk
 
 from . import constants
 from . import network
@@ -276,7 +276,16 @@ def ensure_launcher_shortcuts(app: App):
 def install(app: App):
     """Entrypoint for installing"""
     app.status('Installing…')
-    ensure_launcher_shortcuts(app)
+    try:
+        ensure_launcher_shortcuts(app)
+    except UserExitedFromAsk:
+        # Reset choices, it's possible that the user didn't mean to select
+        # one of the options they did - that is why they are exiting
+        app.conf.faithlife_product = None  # type: ignore[assignment]
+        app.conf.faithlife_product_version = None  # type: ignore[assignment]
+        app.conf.faithlife_product_release = None  # type: ignore[assignment]
+        app.conf.install_dir = None  # type: ignore[assignment]
+        raise
     app.status("Install Complete!", 100)
     # Trigger a config update event to refresh the UIs
     app._config_updated_event.set()

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -4,6 +4,7 @@ import curses
 import logging.handlers
 from typing import Callable, Tuple
 
+from ou_dedetai.app import UserExitedFromAsk
 from ou_dedetai.config import (
     EphemeralConfiguration, PersistentConfiguration, get_wine_prefix_path
 )
@@ -442,7 +443,12 @@ def main():
     # Print terminal banner
     logging.info(f"{constants.APP_NAME}, {constants.LLI_CURRENT_VERSION} by {constants.LLI_AUTHOR}.")  # noqa: E501
 
-    run(ephemeral_config, action)
+    try:
+        run(ephemeral_config, action)
+    except UserExitedFromAsk:
+        # This isn't a critical failure, the user doesn't need a traceback,
+        # they are the ones who told us to exit.
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tested:
- inserting a dummy .ask in ensure_fonts
- TUI advanced install, selected logos, hit main menu on version, then went back into install. Observed main menu restored, also observed using debugger that install thread closed. Hit advanced install again and got prompt to select Logos/Verbum
- GUI, hit install, canceled from dummy question, observed install/advanced install buttons were good again, thread closed, and can hit install again
- CLI, exited from dummy question, program exits with no further text
- CLI, went through dummy question, replied Logos, then exited. Launched CLI again and was re-prompted for Logos as expected