### PR TITLE
fix: release version comparison

### DIFF
--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -91,7 +91,7 @@ PID_FILE = f'/tmp/{BINARY_NAME}.pid'
 FAITHLIFE_PRODUCTS = ["Logos", "Verbum"]
 FAITHLIFE_PRODUCT_VERSIONS = ["10"] # This used to include 9
 
-SUPPORT_MESSAGE = f"If you need help, please consult:\n{WIKI_LINK}\nIf installed failed, use the \"Get Support\" operation"  # noqa: E501
+SUPPORT_MESSAGE = f"If you need help, please consult:\n{WIKI_LINK}\nIf the install failed, use the \"Get Support\" operation"  # noqa: E501
 DEFAULT_SUPPORT_FILE_NAME = "FaithlifeCommunitySupport.zip"
 
 # Strings for choosing a follow up file or directory

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -61,7 +61,7 @@ if RUNMODE == 'snap':
 else:
     CACHE_DIR = str(Path(os.getenv('XDG_CACHE_HOME', Path.home() / '.cache' / 'FaithLife-Community'))) #noqa: E501
 
-DATA_HOME = str(Path(os.getenv('XDG_DATA_HOME', Path.home() / '.local/share') / 'FaithLife-Community')) #noqa: E501
+DATA_HOME = str(Path(os.getenv('XDG_DATA_HOME', str(Path.home() / '.local/share'))) / 'FaithLife-Community') #noqa: E501
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", "~/.config") + "/FaithLife-Community"
 STATE_DIR = os.getenv("XDG_STATE_HOME", "~/.local/state") + "/FaithLife-Community"
 
@@ -91,7 +91,7 @@ PID_FILE = f'/tmp/{BINARY_NAME}.pid'
 FAITHLIFE_PRODUCTS = ["Logos", "Verbum"]
 FAITHLIFE_PRODUCT_VERSIONS = ["10"] # This used to include 9
 
-SUPPORT_MESSAGE = f"If you need help, please consult:\n{WIKI_LINK}\nIf that doesn't answer your question, please use the \"Get Support\" option"  # noqa: E501
+SUPPORT_MESSAGE = f"If you need help, please consult:\n{WIKI_LINK}\nIf installed failed, use the \"Get Support\" operation"  # noqa: E501
 DEFAULT_SUPPORT_FILE_NAME = "FaithlifeCommunitySupport.zip"
 
 # Strings for choosing a follow up file or directory

--- a/ou_dedetai/network.py
+++ b/ou_dedetai/network.py
@@ -585,7 +585,9 @@ def _get_faithlife_product_releases(
         #    break
 
     #Filtering not needed at the moment but left here in case we want it later.
-    #filtered_releases = utils.filter_versions(releases, 40, 1)
+    #Double check this works before releasing.
+    #from packaging.versions import Version
+    #filtered_releases = [version for version in releases if Version("40.0.0.0") > Version(version)] # noqa: E501
     #logging.debug(f"Available releases: {', '.join(releases)}")
     #logging.debug(f"Filtered releases: {', '.join(filtered_releases)}")
 

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -422,9 +422,17 @@ class TUI(App):
                                 self.tui_screens.pop()
 
                     if len(self.tui_screens) == 0:
-                        self.active_screen = self.menu_screen
+                        if self.active_screen != self.menu_screen:
+                            self.current_option = 0
+                            self.current_page = 0
+                            self.total_pages = 0
+                            self.active_screen = self.menu_screen
                     else:
-                        self.active_screen = self.tui_screens[-1]
+                        if self.active_screen != self.tui_screens[-1]:
+                            self.current_option = 0
+                            self.current_page = 0
+                            self.total_pages = 0
+                            self.active_screen = self.tui_screens[-1]
 
                     if not isinstance(self.active_screen, tui_screen.DialogScreen):
                         run_monitor, last_time = utils.stopwatch(last_time, 2.5)

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -119,7 +119,7 @@ def install_dependencies(app: App):
         targetversion = int(app.conf.faithlife_product_version)
     else:
         targetversion = 10
-    app.status(f"Checking {app.conf.faithlife_product} {str(targetversion)} dependencies…")
+    app.status(f"Checking {app.conf.faithlife_product} {str(targetversion)} dependencies…") #noqa: E501
 
     if targetversion == 10:
         system.install_dependencies(app, target_version=10)  # noqa: E501
@@ -161,18 +161,6 @@ def get_current_logos_version(logos_appdata_dir: Optional[str]) -> Optional[str]
             logging.debug("Couldn't determine installed Logos version.")
             return None
     return None
-
-
-def check_logos_release_version(version, threshold, check_version_part):
-    if version is not None:
-        version_parts = list(map(int, version.split('.')))
-        return version_parts[check_version_part - 1] < threshold
-    else:
-        return False
-
-
-def filter_versions(versions, threshold, check_version_part):
-    return [version for version in versions if check_logos_release_version(version, threshold, check_version_part)]  # noqa: E501
 
 
 def get_winebin_code_and_desc(app: App, binary) -> Tuple[str, str | None]:
@@ -435,7 +423,7 @@ def check_appimage(filestr):
 
 
 def find_appimage_files(app: App) -> list[str]:
-    release_version = app.conf.installed_faithlife_product_release or app.conf.faithlife_product_version #noqa: E501
+    release_version = app.conf.installed_faithlife_product_release or app.conf.faithlife_product_release #noqa: E501
     appimages = []
     directories = [
         app.conf.installer_binary_dir,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,14 +146,6 @@ class TestGeneralUtils(unittest.TestCase):
         # TODO: Need to add test for v1 appimage.
         self.assertTrue(utils.check_appimage(self.tiny_appimage))
 
-    def test_check_logos_release_version_false(self):
-        result = utils.check_logos_release_version('1.1.1', 1, 3)
-        self.assertFalse(result)
-
-    def test_check_logos_release_version_true(self):
-        result = utils.check_logos_release_version('1.1.1', 2, 3)
-        self.assertTrue(result)
-
     @unittest.skip("Not testing simple shell command.")
     def test_clean_all(self):
         pass
@@ -191,11 +183,6 @@ class TestGeneralUtils(unittest.TestCase):
     def test_file_exists_true(self):
         self.assertTrue(utils.file_exists('~/.bashrc'))
 
-    def test_filter_versions(self):
-        allvers = ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5']
-        valvers = ['1.0', '1.1', '1.2', '1.3',]
-        filvers = utils.filter_versions(allvers, 4, 2)
-        self.assertEqual(valvers, filvers)
 
     def test_find_installed_product_exists(self):
         name = 'Logos'


### PR DESCRIPTION
Also fixed XDG_DATA_HOME bug, the types were not quite right before.

Also changed the support message to be more clear to use the get support operation

Also fixed some typos where product release was substituted for product version

Tested:
- clean install with latest version -> install succeeds and required_wine_minimum is set to 9.10
- (for testing) removed TRANSFORMS, observed installer exited saying the Logos installer failed.
- `export FLPRODUCT=Logos ;export TARGETVERSION=10 ; export TARGET_RELEASE_VERSION=29.1.0.0022 ` Install using logos < 30 -> minimum wine version is 7.18
- Clean install of Logos < 29 (used same exports as above) -> no transforms
- mocked version filtering via python interactive shell
- exporting XDG_DATA_HOME -> observed Faithlife-Community folder was created and installed into it