### PR TITLE
refactor: use abstract base class in backup

### DIFF
--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -276,7 +276,7 @@ def find_installed_product(faithlife_product: str, wine_prefix: str) -> Optional
     return None
 
 
-def enough_disk_space(dest_dir, bytes_required) -> bool:
+def enough_disk_space(dest_dir, bytes_required: int) -> bool:
     free_bytes = shutil.disk_usage(dest_dir).free
     logging.debug(f"{free_bytes=}; {bytes_required=}")
     return free_bytes > bytes_required
@@ -292,9 +292,9 @@ def get_path_size(file_path: Path|str) -> int:
 
 
 def get_folder_group_size(
-        src_dirs: List[Path] | Tuple[Path],
-        q: queue.Queue[int] | None = None,
-    ) ->  None | int:
+    src_dirs: List[Path] | Tuple[Path],
+    q: queue.Queue[int] | None = None,
+) ->  int:
     src_size = 0
     for d in src_dirs:
         if not d.is_dir():
@@ -302,11 +302,11 @@ def get_folder_group_size(
         src_size += get_path_size(d)
     if q is not None:
         q.put(src_size)
-    else:
-        return src_size
+
+    return src_size
 
 
-def get_latest_folder(folder_path: Path|str) -> Path:
+def get_latest_folder(folder_path: Path|str) -> Optional[Path]:
     folders = [f for f in Path(folder_path).glob('*')]
     if not folders:
         logging.warning(f"No folders found in {folder_path}")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -29,23 +29,23 @@ class TestBackup(unittest.TestCase):
                 nd.mkdir(parents=True)
                 backup_dirs.append(str(nd))
             
-            b = backup.BackupBase(self.app)
+            b = backup.BackupTask(self.app)
             bdirs = b._get_all_backups()
             self.assertEqual(bdirs, backup_dirs)
 
     def test_get_dir_group_size(self):
         size_dir = 4096
 
-        cmd = ['du', '-sb', TESTDATADIR]
+        cmd = ['du', '-sb', str(TESTDATADIR)]
         size_du = int(subprocess.check_output(cmd).decode().split()[0])
         size_testdata = size_du + size_dir  # add in 'data' dir
 
-        cmd = ['du', '-sb', REPODIR / 'snap']
+        cmd = ['du', '-sb', str(REPODIR / 'snap')]
         size_du = int(subprocess.check_output(cmd).decode().split()[0])
         size_snap = size_du + size_dir*3  # add in 'snap', 'bin', 'gui' dirs
 
         self.app.conf.backup_dir = Path('.')
-        b = backup.BackupBase(self.app)
+        b = backup.BackupTask(self.app)
         dirs = [TESTDATADIR, REPODIR / 'snap']
         size = b._get_dir_group_size(dirs)
         self.assertEqual(size_testdata + size_snap, size)
@@ -56,7 +56,6 @@ class TestBackup(unittest.TestCase):
             self.app.conf.backup_dir = d / 'backups'
             self.app.conf._logos_appdata_dir = d / 'Logos'
             b = backup.BackupTask(self.app)
-            b._set_dest_dir()
             self.assertTrue(b.destination_dir)
             self.assertEqual(b.destination_dir.parent, Path(self.app.conf.backup_dir))
 
@@ -73,7 +72,6 @@ class TestRestore(unittest.TestCase):
             self.app.conf._logos_appdata_dir = d / 'Logos'
             self.app.conf.logos_exe = self.app.conf._logos_appdata_dir / 'Logos.exe'
             r = backup.RestoreTask(self.app)
-            r._set_dest_dir()
             self.assertTrue(r.destination_dir)
             self.assertEqual(r.destination_dir, Path(self.app.conf._logos_appdata_dir))
 
@@ -89,6 +87,6 @@ class TestRestore(unittest.TestCase):
             self.app.conf._logos_appdata_dir = d / name
             self.app.conf.logos_exe = self.app.conf._logos_appdata_dir / f'{name}.exe'
             r = backup.RestoreTask(self.app)
-            r.set_source_dir(src_dir)
+            r._source_dir = src_dir
             self.assertTrue(r.source_dir)
             self.assertEqual(r.source_dir, src_dir)


### PR DESCRIPTION
rather than initializing destination_dir to none, then setting it, use abstract functions to populate them.

Also standardized on logos_app_data_dir rather than using logos_app_data_dir in one operation, then logos_exe.parent in another

Resolves type issues reported by mypy

Tested:
- installed Logos, logged in, downloaded resources, made backup, deleted Data/Documents/Users, restored -> success