### PR TITLE
feat: add uninstall button

### DIFF
--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -48,8 +48,8 @@ class CLI(App):
     def remove_index_files(self):
         control.remove_all_index_files(self)
 
-    def remove_install_dir(self):
-        control.remove_install_dir(self)
+    def uninstall(self):
+        control.uninstall(self)
 
     def remove_library_catalog(self):
         control.remove_library_catalog(self)

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -541,14 +541,7 @@ class Config:
         self._raw = PersistentConfiguration.load_from_path(ephemeral_config.config_path)
         self._overrides = ephemeral_config
 
-        def _network_cache_hook():
-            self.app._config_updated_event.set()
-
-        self._network = network.NetworkRequests(
-            ephemeral_config.check_updates_now,
-            hook=_network_cache_hook
-        )
-
+        self._network = self._create_network_requests_with_hook()
         logging.debug("Current persistent config:")
         for k, v in self._raw.__dict__.items():
             logging.debug(f"{k}: {v}")
@@ -560,6 +553,15 @@ class Config:
             logging.debug(f"{k}: {v}")
         logging.debug("End config dump")
 
+    def _create_network_requests_with_hook(self) -> network.NetworkRequests:
+        def _network_cache_hook():
+            self.app._config_updated_event.set()
+
+        return network.NetworkRequests(
+            self._overrides.check_updates_now,
+            hook=_network_cache_hook
+        )
+ 
     def _ask_if_not_found(self, parameter: str, question: str, options: list[str], dependent_parameters: Optional[list[str]] = None) -> str:  #noqa: E501
         if not getattr(self._raw, parameter):
             if dependent_parameters is not None:
@@ -610,12 +612,14 @@ class Config:
         return str(path)
 
     def reload(self):
-        """Re-loads the configuration file on disk"""
+        """Re-loads the configuration from disk"""
         self._raw = PersistentConfiguration.load_from_path(self._overrides.config_path)
+        self._network = self._create_network_requests_with_hook()
         # Also clear out our cached values
         self._logos_exe = self._download_dir = self._wine_output_encoding = None
         self._installed_faithlife_product_release = self._wine_binary_files = None
-        self._wine_appimage_files = None
+        self._wine_appimage_files = self._wine_user = None
+        self._wine64_path = self._user_download_dir = None
 
         self.app._config_updated_event.set()
 

--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -161,17 +161,6 @@ def copy_data(src_dirs, dst_dir):
         shutil.copytree(src, Path(dst_dir) / src.name)
 
 
-def remove_install_dir(app: App):
-    folder = Path(app.conf.install_dir)
-    question = f'Delete "{folder}" and all its contents?'
-    if not folder.is_dir():
-        logging.info(f"Folder doesn't exist: {folder}")
-        return
-    if app.approve(question):
-        shutil.rmtree(folder)
-        logging.info(f"Deleted folder and all its contents: {folder}")
-
-
 def remove_all_index_files(app: App):
     if not app.conf.logos_exe:
         app.exit("Cannot remove index files, Logos is not installed")
@@ -207,6 +196,44 @@ def remove_library_catalog(app: App):
             logging.info(f"Removed: {file_to_remove}")
         except OSError as e:
             logging.error(f"Error removing {file_to_remove}: {e}")
+
+
+def uninstall(app: App):
+    """Completely uninstalls both this app and the installed product"""
+    app.status("Uninstalling…")
+    delete_paths = [
+        app.conf.config_file_path,
+        app.conf.install_dir,
+    ]
+
+    question = "Are you sure you want to uninstall?"
+    context = (
+        "We're about to run:\n\n"
+        "rm -rf " + 
+        " ".join(delete_paths)
+    )
+    if not app.approve(question, context):
+        logging.debug("User refused to uninstall")
+        return
+    if app.approve(
+        "Do you also want to clear the cache and logs?",
+        "If you're debugging make sure you've already hit the \"Get Support\" button; "
+        "we wouldn't want to loose those logs."
+    ):
+        delete_paths += [constants.CACHE_DIR, constants.STATE_DIR]
+
+    for del_path in delete_paths:
+        path = Path(del_path)
+        if not path.exists():
+            continue
+        if path.is_file():
+            os.remove(path)
+        elif path.is_dir():
+            shutil.rmtree(path)
+
+    app.status("Uninstalled")
+
+    app.conf.reload()
 
 
 def get_support(app: App) -> str:

--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -218,7 +218,7 @@ def uninstall(app: App):
     if app.approve(
         "Do you also want to clear the cache and logs?",
         "If you're debugging make sure you've already hit the \"Get Support\" button; "
-        "we wouldn't want to loose those logs."
+        "we wouldn't want to lose those logs."
     ):
         delete_paths += [constants.CACHE_DIR, constants.STATE_DIR]
 

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -229,6 +229,12 @@ class ControlGui(StatusGui):
             variable=self.actionsvar,
             value='remove-index-files',
         )
+        self.uninstall_radio = Radiobutton(
+            self,
+            text="Uninstall",
+            variable=self.actionsvar,
+            value='uninstall',
+        )
         self.install_icu_radio = Radiobutton(
             self,
             text="Install/Update ICU files",
@@ -287,6 +293,8 @@ class ControlGui(StatusGui):
         row += 1
         self.actions_button.grid(column=0, row=row, sticky='e', padx=20, pady=2)  # noqa: E501
         self.remove_index_files_radio.grid(column=1, row=row, sticky='w', pady=2, columnspan=2)  # noqa: E501
+        row += 1
+        self.uninstall_radio.grid(column=1, row=row, sticky='w', pady=2, columnspan=2)  # noqa: E501
         row += 1
         self.install_icu_radio.grid(column=1, row=row, sticky='w', pady=2, columnspan=2)  # noqa: E501
         row += 1

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -108,7 +108,7 @@ class GuiApp(App):
     def approve(self, question: str, context: str | None = None) -> bool:
         if context is None:
             context = ""
-        message = f"{context}\n{question}"
+        message = f"{context}\n\n{question}"
         return messagebox.askquestion(question, message.strip()) == 'yes'
 
     def _exit(self, reason: str, intended: bool = False):
@@ -443,6 +443,9 @@ class ControlWindow(GuiApp):
         self.gui.remove_index_files_radio.config(
             command=self.on_action_radio_clicked
         )
+        self.gui.uninstall_radio.config(
+            command=self.on_action_radio_clicked
+        )
         self.gui.install_icu_radio.config(
             command=self.on_action_radio_clicked
         )
@@ -520,6 +523,8 @@ class ControlWindow(GuiApp):
                 self.actioncmd = self.remove_indexes
             elif self.gui.actionsvar.get() == 'install-icu':
                 self.actioncmd = self.install_icu
+            elif self.gui.actionsvar.get() == 'uninstall':
+                self.actioncmd = self.uninstall
 
     def run_indexing(self):
         self.start_thread(self.logos.index)
@@ -534,6 +539,13 @@ class ControlWindow(GuiApp):
     def install_icu(self):
         self.gui.statusvar.set("Installing ICU files…")
         self.start_thread(wine.enforce_icu_data_files, app=self)
+
+    def uninstall(self):
+        def _run():
+            control.uninstall(self)
+            self.clear_status()
+            self.populate_defaults()
+        self.start_thread(_run)
 
     def run_backup(self, evt=None):
         # Prepare progress bar.
@@ -614,10 +626,13 @@ class ControlWindow(GuiApp):
             self.gui.app_button.config(command=self.run_logos)
             self.gui.logging_button.state(['!disabled'])
             self.gui.app_install_advanced.grid_forget()
+            self.gui.actions_button.state(['!disabled'])
         else:
+            self.gui.app_buttonvar.set("Install")
             self.gui.app_button.config(command=self.run_install)
             self.gui.app_install_advanced.config(command=self.run_installer)
             self.gui.show_advanced_install_button()
+            self.gui.actions_button.state(['disabled'])
             # Make sure the product/version/channel/release is non-None
             if None not in [
                 self.conf._raw.faithlife_product,

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -172,8 +172,8 @@ def get_parser():
         help='[re-]create app shortcuts',
     )
     cmd.add_argument(
-        '--remove-install-dir', action='store_true',
-        help='delete the current installation folder',
+        '--uninstall', action='store_true',
+        help='Completely delete the faithlife software from your system',
     )
     cmd.add_argument(
         '--dirlink', action='store_true',
@@ -280,7 +280,7 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
         'install_dependencies',
         'install_icu',
         'remove_index_files',
-        'remove_install_dir',
+        'uninstall',
         'remove_library_catalog',
         'restore',
         'run_indexing',

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -980,9 +980,17 @@ class TUI(App):
                 "Remove Library Catalog",
                 "Remove All Index Files",
                 "Install ICU",
-                "Uninstall"
             ]
             labels.extend(labels_catalog)
+        
+        # FIXME: #367 rework uninstall to work without a successful install
+        if self.is_installed():
+            label_user_data_utilities = [
+                "Uninstall"
+                # "Back Up Data",
+                # "Restore Data"
+            ]
+            labels.extend(label_user_data_utilities)
 
         labels_utilities = ["Install Dependencies", "Edit Config", "Reload Config"]
         labels.extend(labels_utilities)
@@ -991,8 +999,6 @@ class TUI(App):
             labels_utils_installed = [
                 "Change Logos Release Channel",
                 f"Change {constants.APP_NAME} Release Channel",
-                # "Back Up Data",
-                # "Restore Data"
             ]
             labels.extend(labels_utils_installed)
 


### PR DESCRIPTION
Fixes: https://github.com/FaithLife-Community/OuDedetai/issues/233

Removes the --remove-install-dir cli argument and adds --uninstall

Tested:
- CLI (Yes, No), (No), (Yes, Yes)
- GUI (No), (Yes, No, Then install again) (Yes, Yes). Note: This will re-create a clean config and cache after uninstall due to GUI enforcing settings
- TUI (Return to main menu), (Yes, Return to Main Menu), ((Yes, No), Install, (Yes, Yes))