### PR TITLE
feat: add progress bar to CLI

### DIFF
--- a/ou_dedetai/app.py
+++ b/ou_dedetai/app.py
@@ -208,8 +208,7 @@ class App(abc.ABC):
         """A status update
         
         Args:
-            message: str - if it ends with a \r that signifies that this message is
-                intended to be overrighten next time
+            message: str - message to send to user
             percent: Optional[int] - percent of the way through the current install step
                 (if installing)
         """
@@ -237,13 +236,13 @@ class App(abc.ABC):
         """Implementation for updating status pre-front end
         
         Args:
-            message: str - if it ends with a \r that signifies that this message is
-                intended to be overridden next time
+            message: str - message to send to user
             percent: Optional[int] - percent complete of the current overall operation
                 if None that signifies we can't track the progress.
                 Feel free to implement a spinner
         """
 
+        # XXX: this isn't used in any App..
         def get_progressbar(pct, w=10, suffix=''):
             suffix = f" {int(pct):>3}%"
             # end = '\r'

--- a/ou_dedetai/app.py
+++ b/ou_dedetai/app.py
@@ -231,6 +231,8 @@ class App(abc.ABC):
             self._status(message, percent)
         self._last_status = message
 
+    # FIXME: This implementation is overridden in every implementation
+    # Perhaps this should just raise NotImplementedError to avoid confusion?
     @abc.abstractmethod
     def _status(self, message: str, percent: Optional[int] = None):
         """Implementation for updating status pre-front end
@@ -242,7 +244,6 @@ class App(abc.ABC):
                 Feel free to implement a spinner
         """
 
-        # XXX: this isn't used in any App..
         def get_progressbar(pct, w=10, suffix=''):
             suffix = f" {int(pct):>3}%"
             # end = '\r'

--- a/ou_dedetai/backup.py
+++ b/ou_dedetai/backup.py
@@ -108,7 +108,7 @@ class BackupBase(abc.ABC):
         t = self.app.start_thread(self._copy_dirs, src_dirs, self.destination_dir)
         try:
             while t.is_alive():
-                self.app.status("copying…\r", self._get_copy_percentage())
+                self.app.status("copying…", self._get_copy_percentage())
                 time.sleep(0.5)
             print()
         except KeyboardInterrupt:

--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -170,14 +170,6 @@ class CLI(App):
         if percent is not None and percent > 100:
             percent = 100
         progress_str = ""
-        # Carriage return at the start signifies we want to overwrite the last line.
-        if message.startswith("\r") or message == self._last_status:
-            # Go back up one line to re-write the line and progress
-            # This allows the current line to update
-            # Type is ignored on the following line due to supposed error in 
-            # curses.tparm, however the code works, and value is static. it is safe.
-            print((curses.tparm(curses.tigetstr("cuu")) + b"\r").decode(), end="") # type: ignore
-            message = message.lstrip("\r")
         # We don't want to display 100% as it doesn't print nicely.
         if percent is not None:
             # -2 is for the brackets, -1 is for the >

--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -174,7 +174,8 @@ class CLI(App):
             chars_remaining = progress_bar_length - chars_of_progress
             progress_str = "[" + "-" * chars_of_progress + ">" + " " * chars_remaining + "]" #noqa: E501
 
-        self.print(message)
+        if message != self._last_status:
+            self.print(message)
         # Write my progress then carriage return
         # (so we're back at the beginning for the next log line)
         if progress_str:

--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -97,7 +97,7 @@ def backup_and_restore(mode: str, app: App):
         while t.is_alive():
             i += 1
             i = i % 20
-            app.status(f"{message}{'.' * i}\r")
+            app.status(f"\r{message}{'.' * i}")
             time.sleep(0.5)
     except KeyboardInterrupt:
         print()

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -90,7 +90,7 @@ class GuiApp(App):
         InfoPopUp(message)
 
     def _status(self, message, percent = None):
-        message = message.strip("\r")
+        message = message.strip()
         if percent is not None:
             self._status_gui.progress.stop()
             self._status_gui.progress.state(['disabled'])

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -89,7 +89,7 @@ class GuiApp(App):
         InfoPopUp(message)
 
     def _status(self, message, percent = None):
-        message = message.lstrip("\r")
+        message = message.strip("\r")
         if percent is not None:
             self._status_gui.progress.stop()
             self._status_gui.progress.state(['disabled'])

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -904,7 +904,7 @@ class TUI(App):
         self.ask_answer_event.clear()
 
     def _status(self, message: str, percent: int | None = None):
-        message = message.strip("\r")
+        message = message.strip()
         if self.console_log[-1] == message:
             return
         self.console_log.append(message)

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -895,7 +895,7 @@ class TUI(App):
         self.ask_answer_event.clear()
 
     def _status(self, message: str, percent: int | None = None):
-        message = message.lstrip("\r")
+        message = message.strip("\r")
         if self.console_log[-1] == message:
             return
         self.console_log.append(message)


### PR DESCRIPTION
It should be noted this restricts the CLI to only working on *NIX system - as it uses curses

Tested:
- Ran clean install, saw progress bar and no artifacts, and after OD completed, could interact with terminal again