### PR TITLE
test: expand integration test

### DIFF
--- a/tests/integration.py
+++ b/tests/integration.py
@@ -93,7 +93,7 @@ class OuDedetai:
     def isolate_files(self):
         if self._temp_dir is not None:
             shutil.rmtree(self._temp_dir)
-        # XXX: this isn't properly cleaned up. Context manager?
+        # FIXME: this isn't properly cleaned up when tests fail. Context manager?
         self._temp_dir = tempfile.mkdtemp()
         self.config = Path(self._temp_dir) / "config.json"
         self.install_dir = Path(self._temp_dir) / "install_dir"
@@ -171,7 +171,7 @@ class OuDedetai:
             self.stop_app()
         except Exception:
             pass
-        # XXX: Ideally the uninstall operation would automatically stop the app.
+        # FIXME: Ideally the uninstall operation would automatically stop the app.
         # Open an issue for this.
         self.run(["--uninstall", "-y"])
 
@@ -195,7 +195,7 @@ class OuDedetai:
         # FIXME: wait for close?
 
 
-# XXX: test this against Verbum too. It should be the same.
+# FIXME: test this against Verbum too. It should be the same.
 # If not, make this an abstract class w/overrides.
 
 class Logos:


### PR DESCRIPTION
Now the integration test:
- Tests clean install
- Tests first time resource download
- Tests the following tools/guides to ensure they don't crash
  - open bible
  - copy bible verses
  - factbook
- ensures crash detection logic works (with a test!)

Lots of room to expand this, and obvious integrate into unittest somehow (we'll need to be able to filter these tests separately as their design goals is different). These tests are designed for: Does OD install Logos in such a way that it doesn't crash when doing normal tasks? While unittest is designed for: does the python do what we expect it to do?

This file should also be broken up when it's integrated, kept as one file for now, but it will be split.