### PR TITLE
fix: stop Verbum

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -1099,19 +1099,20 @@ class Config:
     @property
     def logos_cef_exe(self) -> Optional[str]:
         if self.wine_user is not None:
-            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\Logos\\System\\LogosCEF.exe'  # noqa: E501
+            # This name is the same even in Verbum
+            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\{self.faithlife_product}\\System\\LogosCEF.exe'  # noqa: E501
         return None
 
     @property
     def logos_indexer_exe(self) -> Optional[str]:
         if self.wine_user is not None:
-            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\Logos\\System\\LogosIndexer.exe'  # noqa: E501
+            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\{self.faithlife_product}\\System\\{self.faithlife_product}Indexer.exe'  # noqa: E501
         return None
 
     @property
     def logos_login_exe(self) -> Optional[str]:
         if self.wine_user is not None:
-            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\Logos\\System\\Logos.exe'  # noqa: E501
+            return f'C:\\users\\{self.wine_user}\\AppData\\Local\\{self.faithlife_product}\\System\\{self.faithlife_product}.exe'  # noqa: E501
         return None
 
     @property

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -82,7 +82,7 @@ class LogosManager:
             self.existing_processes[app.conf.logos_exe] = system.get_pids(app.conf.logos_exe) # noqa: E501
         if app.conf.wine_user:
             # Also look for the system's Logos.exe (this may be the login window)
-            logos_system_exe = f"C:\\users\\{app.conf.wine_user}\\AppData\\Local\\Logos\\System\\Logos.exe" #noqa: E501
+            logos_system_exe = f"C:\\users\\{app.conf.wine_user}\\AppData\\Local\\{app.conf.faithlife_product}\\System\\{app.conf.faithlife_product}.exe" #noqa: E501
             self.existing_processes[logos_system_exe] = system.get_pids(logos_system_exe) # noqa: E501
         if app.conf.logos_indexer_exe:
             self.existing_processes[app.conf.logos_indexer_exe] = system.get_pids(app.conf.logos_indexer_exe)  # noqa: E501


### PR DESCRIPTION
Some paths had a hard coded "Logos" in them

The first bug exposed by integration testing!

Tested:
- Launched Verbum
- Used oudedetai --stop-installed-app
- Verbum closed