### PR TITLE
fix: wine logging

### DIFF
--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -1,5 +1,6 @@
 import queue
 import shutil
+import sys
 import threading
 import time
 from typing import Optional, Tuple
@@ -72,14 +73,30 @@ class CLI(App):
         self.logos.stop()
 
     def winetricks(self):
-        wine.run_winetricks(self, *(self.conf._overrides.wine_args or []))
-
-    def wine(self):
-        wine.run_wine_proc(
-            self.conf.wine64_binary,
+        process = wine.run_wine_process(
             self,
+            self.conf.winetricks_binary,
+            sys.stdout,
+            sys.stderr,
+            sys.stdin,
             exe_args=(self.conf._overrides.wine_args or [])
         )
+        if process:
+            process.wait()
+            sys.exit(process.returncode)
+
+    def wine(self):
+        process = wine.run_wine_process(
+            self,
+            self.conf.wine64_binary,
+            sys.stdout,
+            sys.stderr,
+            sys.stdin,
+            exe_args=(self.conf._overrides.wine_args or [])
+        )
+        if process:
+            process.wait()
+            sys.exit(process.returncode)
 
     def set_appimage(self):
         utils.set_appimage_symlink(app=self)

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -158,9 +158,7 @@ def ensure_wineprefix_init(app: App):
     if not init_file.is_file():
         logging.debug(f"{init_file} does not exist")
         logging.debug("Initializing wineprefix.")
-        process = wine.initializeWineBottle(app.conf.wine64_binary, app)
-        if process:
-            process.wait()
+        wine.initializeWineBottle(app.conf.wine64_binary, app)
         # wine.light_wineserver_wait()
         wine.wineserver_wait(app)
         logging.debug("Wine init complete.")

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -111,9 +111,9 @@ class LogosManager:
             self.set_auto_updates(False)
             if not self.app.conf.logos_exe:
                 raise ValueError("Could not find installed Logos EXE to run")
-            process = wine.run_wine_proc(
-                self.app.conf.wine_binary,
+            process = wine.run_wine_application(
                 self.app,
+                self.app.conf.wine_binary,
                 exe=self.app.conf.logos_exe
             )
             if process is not None:
@@ -255,9 +255,9 @@ class LogosManager:
         def run_indexing():
             if not self.app.conf.logos_indexer_exe:
                 raise ValueError("Cannot find installed indexer")
-            process = wine.run_wine_proc(
-                self.app.conf.wine_binary,
+            process = wine.run_wine_application(
                 app=self.app,
+                wine_binary=self.app.conf.wine_binary,
                 exe=self.app.conf.logos_indexer_exe
             )
             if process is not None:
@@ -363,9 +363,9 @@ class LogosManager:
             'add', 'HKCU\\Software\\Logos4\\Logging', '/v', 'Enabled',
             '/t', 'REG_DWORD', '/d', value, '/f'
         ]
-        process = wine.run_wine_proc(
-            self.app.conf.wine_binary,
+        process = wine.run_wine_during_install(
             app=self.app,
+            wine_binary=self.app.conf.wine_binary,
             exe='reg',
             exe_args=exe_args
         )

--- a/ou_dedetai/repair.py
+++ b/ou_dedetai/repair.py
@@ -53,6 +53,11 @@ def detect_broken_install(
         # No other checks we can preform without the logos_user_id
         return None
 
+    # FIXME: Add step looking for a .NET stacktrace and suggest reaching out to support
+    # with logs. This probably should be in a different function and checked before
+    # logos is run. Look for failures using:
+    # `grep ":err:eventlog:ReportEventW" ~/.local/state/FaithLife-Community/wine.log`
+
     # Recovery is best-effort we don't want to crash the app on account of failures here
     try:
         with ou_dedetai.database.LocalUserPreferencesManager(logos_app_dir, logos_user_id) as db: #noqa: E501

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -140,6 +140,7 @@ def run_command(command, retries=1, delay=0, **kwargs) -> Optional[subprocess.Co
     return None
 
 
+# FIXME: #300 refactor this to either return Popen or raise. No None.
 def popen_command(command, retries=1, delay=0, **kwargs) -> Optional[subprocess.Popen[bytes]]: #noqa: E501
     shell = kwargs.get("shell", False)
     env = kwargs.get("env", None)

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from packaging.version import Version
 import tempfile
-from typing import Optional
+from typing import IO, Optional
 
 from ou_dedetai import constants
 from ou_dedetai.app import App
@@ -20,32 +20,36 @@ def check_wineserver(app: App):
     # (or at least kill it). Gotten into several states in dev where this happend
     # Normally when an msi install failed
     try:
-        process = run_wine_proc(app.conf.wineserver_binary, app)
+        process = run_wine_during_install(app, app.conf.wineserver_binary)
         if not process:
             logging.debug("Failed to spawn wineserver to check it")
             return False
-        process.wait()
-        return process.returncode == 0
-    except Exception:
+    except subprocess.CalledProcessError:
         return False
 
 
 def wineserver_kill(app: App):
     if check_wineserver(app):
-        process = run_wine_proc(app.conf.wineserver_binary, app, exe_args=["-k"])
+        process = run_wine_during_install(
+            app,
+            app.conf.wineserver_binary,
+            exe_args=["-k"]
+        )
         if not process:
             logging.debug("Failed to spawn wineserver to kill it")
             return False
-        process.wait()
 
 
 def wineserver_wait(app: App):
     if check_wineserver(app):
-        process = run_wine_proc(app.conf.wineserver_binary, app, exe_args=["-w"])
+        process = run_wine_during_install(
+            app,
+            app.conf.wineserver_binary,
+            exe_args=["-w"]
+        )
         if not process:
             logging.debug("Failed to spawn wineserver to wait for it")
             return False
-        process.wait()
 
 
 @dataclass
@@ -227,34 +231,31 @@ def check_wine_version_and_branch(release_version: Optional[str], test_binary,
     return True, "None"
 
 
-def initializeWineBottle(wine64_binary: str, app: App) -> Optional[subprocess.Popen[bytes]]: #noqa: E501
+def initializeWineBottle(wine64_binary: str, app: App):
     app.status("Initializing wine bottle…")
     logging.debug(f"{wine64_binary=}")
     # Avoid wine-mono window
     wine_dll_override="mscoree="
     logging.debug(f"Running: {wine64_binary} wineboot --init")
-    process = run_wine_proc(
-        wine64_binary,
+    run_wine_during_install(
         app=app,
+        wine_binary=wine64_binary,
         exe='wineboot',
         exe_args=['--init'],
         init=True,
         additional_wine_dll_overrides=wine_dll_override
     )
-    return process
 
 
 def set_win_version(app: App, exe: str, windows_version: str):
     if exe == "logos":
         # This operation is equivilent to f"winetricks -q settings {windows_version}"
         # but faster
-        process = run_wine_proc(
-            app.conf.wine_binary,
+        run_wine_during_install(
             app,
+            app.conf.wine_binary,
             exe_args=('winecfg', '/v', windows_version)
         )
-        if process:
-            process.wait()
 
     elif exe == "indexer":
         reg = f"HKCU\\Software\\Wine\\AppDefaults\\{app.conf.faithlife_product}Indexer.exe"  # noqa: E501
@@ -265,15 +266,14 @@ def set_win_version(app: App, exe: str, windows_version: str):
             "/t", "REG_SZ",
             "/d", f"{windows_version}", "/f",
             ]
-        process = run_wine_proc(
-            app.conf.wine_binary,
+        process = run_wine_during_install(
             app,
+            app.conf.wine_binary,
             exe='reg',
             exe_args=exe_args
         )
         if process is None:
             app.exit("Failed to spawn command to set windows version for indexer")
-        process.wait()
 
 
 def wine_reg_query(app: App, key_name: str, value_name: str) -> Optional[str]:
@@ -289,9 +289,9 @@ def wine_reg_query(app: App, key_name: str, value_name: str) -> Optional[str]:
 
     ```
     """ #noqa: E501
-    process = run_wine_proc_completed_process(
-        app.conf.wine64_binary,
+    process = run_wine_completed_process(
         app=app,
+        wine_binary=app.conf.wine64_binary,
         exe="reg.exe",
         exe_args=[
             "query",
@@ -329,22 +329,20 @@ def wine_reg_install(app: App, name: str, reg_text: str, wine64_binary: str):
         reg_file.write_text(reg_text)
         app.status(f"Installing registry file: {reg_file}")  
         try:
-            process = run_wine_proc(
-                wine64_binary,
+            process = run_wine_during_install(
                 app=app,
+                wine_binary=wine64_binary,
                 exe="regedit.exe",
                 exe_args=[str(reg_file)]
             )
             if process is None:
                 app.exit("Failed to spawn command to install reg file")
-            process.wait()
-            if process is None or process.returncode != 0:
-                failed = "Failed to install reg file"
-                logging.debug(f"{failed}. {process=}")
-                app.exit(f"{failed}: {reg_file}")
-            elif process.returncode == 0:
-                logging.info(f"{reg_file} installed.")
+            logging.info(f"{reg_file} installed.")
             wineserver_wait(app)
+        except subprocess.CalledProcessError:
+            failed = "Failed to install reg file"
+            logging.exception(f"{failed}. {process=}")
+            app.exit(f"{failed}: {reg_file}")
         finally:
             reg_file.unlink()
 
@@ -392,7 +390,7 @@ def set_fontsmoothing_to_rgb(app: App, wine64_binary: str):
 def install_msi(app: App):
     app.status(f"Running MSI installer: {app.conf.faithlife_installer_name}.")
     # Define the Wine executable and initial arguments for msiexec
-    wine_exe = app.conf.wine64_binary
+    wine_binary = app.conf.wine64_binary
     exe_args = ["/i", f"{app.conf.install_dir}/data/{app.conf.faithlife_installer_name}"]  # noqa: E501
 
     # Add passive mode if specified
@@ -409,17 +407,17 @@ def install_msi(app: App):
     if release_version is not None and Version(release_version) > Version("39.0.0.0"): #noqa: E501
         # Define MST path and transform to windows path.
         mst_path = constants.APP_ASSETS_DIR / "LogosStubFailOK.mst"
-        transform_winpath = run_wine_proc_completed_process(
-            wine_exe,
+        transform_winpath = run_wine_completed_process(
             app=app,
+            wine_binary=wine_binary,
             exe_args=['winepath', '-w', mst_path]
         ).stdout.rstrip()
         exe_args.append(f'TRANSFORMS={transform_winpath}')
         logging.debug(f"TRANSFORMS windows path added: {transform_winpath}")
 
     # Log the msiexec command and run the process
-    logging.info(f"Running: {wine_exe} msiexec {' '.join(exe_args)}")
-    result = run_wine_proc(wine_exe, app, exe="msiexec", exe_args=exe_args)
+    logging.info(f"Running: {wine_binary} msiexec {' '.join(exe_args)}")
+    result = run_wine_during_install(app, wine_binary, exe="msiexec", exe_args=exe_args)
     if result is not None:
         # Wait in order to get the exit status.
         result.wait()
@@ -433,12 +431,12 @@ def run_winetricks(app: App, *args):
     if "-q" not in args and app.conf.winetricks_binary:
         cmd.insert(0, "-q")
     logging.info(f"running \"winetricks {' '.join(cmd)}\"")
-    process = run_wine_proc(app.conf.winetricks_binary, app, exe_args=cmd)
-    if process is None:
-        app.exit("Failed to spawn winetricks")
-    logging.debug(f"Waiting for \"winetricks {' '.join(cmd)}\" To complete")
-    process.wait()
-    if process.returncode != 0:
+    try:
+        process = run_wine_during_install(app, app.conf.winetricks_binary, exe_args=cmd)
+        if process is None:
+            app.exit("Failed to spawn winetricks")
+    except subprocess.CalledProcessError:
+        logging.exception(f"\"winetricks {' '.join(cmd)}\" Failed!")
         app.exit(f"\"winetricks {' '.join(cmd)}\" Failed!")
     logging.info(f"\"winetricks {' '.join(cmd)}\" DONE!")
     logging.debug(f"procs using {app.conf.wine_prefix}:")
@@ -494,11 +492,11 @@ def get_winecmd_encoding(app: App) -> Optional[str]:
         return None
 
 
-def run_wine_proc_completed_process(
-    winecmd,
+def run_wine_completed_process(
     app: App,
+    wine_binary: str,
     exe=None,
-    exe_args=list(),
+    exe_args=None,
     additional_wine_dll_overrides: Optional[str] = None,
 ) -> subprocess.CompletedProcess[str]:
     """Like run_wine_proc but outputs a CompletedProcess
@@ -507,7 +505,7 @@ def run_wine_proc_completed_process(
     Useful when wanting to parse the output for wine commands
     """
     env = get_wine_env(app, additional_wine_dll_overrides)
-    command = [winecmd]
+    command = [wine_binary]
     if exe is not None:
         command.append(exe)
     if exe_args:
@@ -520,42 +518,133 @@ def run_wine_proc_completed_process(
     )
 
 
-def run_wine_proc(
-    winecmd,
+def run_wine_process(
     app: App,
+    wine_binary: str | Path,
+    stdout: IO[str],
+    stderr: IO[str],
+    stdin = None,
     exe=None,
-    exe_args=list(),
-    init=False,
+    exe_args=None,
     additional_wine_dll_overrides: Optional[str] = None,
 ) -> Optional[subprocess.Popen[bytes]]:
+    """Runs wine directly
+    
+    Args:
+    - app: App
+    - stdout: Where to send stdout, must be a file descriptor
+    - stderr: Where to send stderr, must be a file descriptor
+    - stderr: Where stdin should come from, must be a file descriptor
+    - exe: The windows executable to run
+    - exe_args: arguments to the aforementioned exe
+    - init: whether or not this call is to initialize the bottle
+    - additional_wine_dll_overrides: Add to WINEDLLOVERRIDES
+    """
     env = get_wine_env(app, additional_wine_dll_overrides)
-    if isinstance(winecmd, Path):
-        winecmd = str(winecmd)
-    logging.debug(f"run_wine_proc: {winecmd}; {exe=}; {exe_args=}")
+    if isinstance(wine_binary, Path):
+        wine_binary = str(wine_binary)
 
-    command = [winecmd]
+    command = [wine_binary]
     if exe is not None:
         command.append(exe)
     if exe_args:
         command.extend(exe_args)
 
-    cmd = f"subprocess cmd: '{' '.join(command)}'"
+    cmd = f"Running wine cmd: '{' '.join(command)}'"
     logging.debug(cmd)
     try:
-        with open(app.conf.app_wine_log_path, 'a') as wine_log:
-            print(f"{utils.get_timestamp()}: {cmd}", file=wine_log)
-            return system.popen_command(
-                command,
-                stdout=wine_log,
-                stderr=wine_log,
-                env=env,
-                start_new_session=True,
-                encoding='utf-8'
-            )
+        stdout.write(f"{utils.get_timestamp()}: {cmd}\n")
+        # FIXME: consider calling Popen directly here so we can remove the
+        # run_wine_proc_completed_process function - as it is nearly a duplicate
+        # of this one, but with a different arg to Popen.
+        return system.popen_command(
+            command,
+            stdout=stdout,
+            stderr=stderr,
+            stdin=stdin,
+            env=env,
+            start_new_session=True,
+            encoding='utf-8'
+        )
 
     except subprocess.CalledProcessError as e:
         logging.error(f"Exception running '{' '.join(command)}': {e}")
     return None
+
+
+def run_wine_application(
+    app: App,
+    wine_binary: str | Path,
+    exe=None,
+    exe_args=None,
+    additional_wine_dll_overrides: Optional[str] = None,
+) -> Optional[subprocess.Popen[bytes]]:
+    """Run a wine application.
+     
+    Store the log in a dedicated file, keeping the previous log.
+    """
+    current_log_path = Path(app.conf.app_wine_log_path)
+    previous_log_path = current_log_path.with_suffix(".1" + current_log_path.suffix)
+    if current_log_path.exists():
+        shutil.move(current_log_path, previous_log_path)
+    with open(current_log_path, 'w') as wine_log:
+        return run_wine_process(
+            app=app,
+            wine_binary=wine_binary,
+            stdout=wine_log,
+            stderr=wine_log,
+            exe=exe,
+            exe_args=exe_args,
+            additional_wine_dll_overrides=additional_wine_dll_overrides
+        )
+
+
+def run_wine_during_install(
+    app: App,
+    wine_binary: str | Path,
+    exe=None,
+    exe_args=list(),
+    init=False,
+    additional_wine_dll_overrides: Optional[str] = None,
+) -> Optional[subprocess.Popen[bytes]]:
+    """Runs a wine process as part of the install process.
+    Waits for wine to complete before returning.
+    Checks exit code to ensure it is 0
+    
+    Logs are dumped in the python logger (subject to their rotation).
+    This function also waits on the process to finish.
+    
+    Raises:
+    - subprocess.CalledProcessError if returncode != 0
+    """
+    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+        process = run_wine_process(
+            app=app,
+            wine_binary=wine_binary,
+            stdout=temp_file,
+            stderr=temp_file,
+            exe=exe,
+            exe_args=exe_args,
+            additional_wine_dll_overrides=additional_wine_dll_overrides
+        )
+        if process:
+            full_command_string = f"{wine_binary} {exe} {" ".join(exe_args)}"
+            logging.debug(f"Waiting on: {full_command_string}")
+            process.wait()
+            logging.debug(f"Wine process {full_command_string} "
+                          f"completed with: {process.returncode}. "
+                          "Dumping log:")
+            # Now read from the tempfile and echo into our application log.
+            with open(temp_file.name, "r") as temp_log_file:
+                while line := temp_log_file.readline():
+                    logging.debug(f"> {line.rstrip()}")
+            logging.debug(f"Finished dumping log {full_command_string}")
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    process.returncode,
+                    cmd=full_command_string,
+                )
+    return process
 
 
 # FIXME: Consider when to re-run this if it changes.


### PR DESCRIPTION
Logos/Verbum (Indexer) now log to the wine log file, with their previous run logging to wine.1.log

All other wine executions as part of the install process now go into OD's log

Fixes: #376

Tested:
- run logos, log is in wine.log, launching a second time, it's moved to wine.1.log, and the new one is at wine.log
- clean install (confirm log is expected)
- during install msi TRANSFORMS functions, and msiexec logs are in OD's
- winetricks logs during install are in OD's
- during install winemenubuilder/renderer/fontsmoothing logs are in OD's
- TUI set windows version
- switch Logos logging wine execution goes into OD's log (looks to be empty)
- install fonts detects existing arial font
- ran indexing (confirm log as expected)
- winetricks command, make sure stdout/stderr/exitcode are passed correctly (didn't confirm stdin, don't know what takes this. Fortunately code is the same for wine, and it worked.)
- wine command, make sure stdout/stderr/stdin are passed correctly