### PR TITLE
fix: incorrect TUI ratio value

### DIFF
--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -90,9 +90,9 @@ class TUI(App):
 
         self.header_window_ratio: float = 0.10
         self.console_window_ratio: float = 0.15
-        self.main_window_ratio: float = 0.10
+        self.main_window_ratio: float = 0.55
         # Intentionally short this by 10% to avoid hidden lines
-        self.footer_window_ratio: float = 0.55
+        self.footer_window_ratio: float = 0.10
 
         self.header_window: Optional[curses.window] = None
         self.console_window: Optional[curses.window] = None


### PR DESCRIPTION
Following #379, which I merged without fully testing in order to be able to test other PRs, I found there was a regression in the PR. This turned out to be an incorrectly assigned value.