### PR TITLE
chore(release): update version to 4.0.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+- 4.0.0-beta.11
+	- Fixes bug where the TUI didn't open (#379, #382) [N. Shaaban, T. H. Wright]
+	- Fixes bug where Verbum didn't stop when told (#374) [N. Shaaban]
+	- Functionality restored to Backup/Restore on CLI (#345) [N. Marti]
+	- Properly rotate wine.log (#378, #376) [N. Shaaban]
+	- Adds proper progress bar to CLI (#370) [N. Shaaban]
 - 4.0.0-beta.10
 	- Fixes bug where advanced GUI install failed (#354) [N. Shaaban]
 	- Adds a new option: "Get Support" to create a zip and display our social groups (#353, #274, #103) [N. Shaaban]

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -79,7 +79,7 @@ LEGACY_CONFIG_FILES = [
     os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.conf")
 ]
 LLI_AUTHOR = "Ferion11, John Goodman, T. H. Wright, N. Marti, N. Shaaban"
-LLI_CURRENT_VERSION = "4.0.0-beta.10"
+LLI_CURRENT_VERSION = "4.0.0-beta.11"
 # This SHOULD match the version of winetricks we ship in the latest appimage
 WINETRICKS_VERSION = '20250102'
 DEFAULT_LOG_LEVEL = logging.WARNING


### PR DESCRIPTION
Tested:
- Clean install, running logos shows login screen for Logos 40.2
- launch TUI, shown main menu
- launch GUI, shown control panel

Post-release:
- Make sure GLIBC version is old enough
- Make sure oudedetai x86 binary is at the top and named oudedetai (may need to download the binary, rename it locally, then re-upload). This may or may not matter, our code MAY assume one name over the other.