### PR TITLE
fix: include last wine log in support package

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -1049,6 +1049,11 @@ class Config:
         return constants.DEFAULT_APP_WINE_LOG_PATH
 
     @property
+    def app_wine_log_previous_path(self) -> str:
+        wine_log = Path(self.app_wine_log_path)
+        return str(wine_log.with_suffix(".1" + wine_log.suffix))
+
+    @property
     def app_log_path(self) -> str:
         if self._overrides.app_log_path is not None:
             return self._overrides.app_log_path

--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -124,6 +124,8 @@ def get_support(app: App) -> str:
             zip.write(app.conf.app_log_path)
         if Path(app.conf.app_wine_log_path).exists():
             zip.write(app.conf.app_wine_log_path)
+        if Path(app.conf.app_wine_log_previous_path).exists():
+            zip.write(app.conf.app_wine_log_previous_path)
         if Path("/etc/os-release").exists():
             zip.write("/etc/os-release")
         run_commands = [

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -587,7 +587,7 @@ def run_wine_application(
     Store the log in a dedicated file, keeping the previous log.
     """
     current_log_path = Path(app.conf.app_wine_log_path)
-    previous_log_path = current_log_path.with_suffix(".1" + current_log_path.suffix)
+    previous_log_path = Path(app.conf.app_wine_log_previous_path)
     if current_log_path.exists():
         shutil.move(current_log_path, previous_log_path)
     with open(current_log_path, 'w') as wine_log:


### PR DESCRIPTION
Tested (on existing install pre-login):
- ran logos twice, generated support zip, extracted support zip, saw last wine log present
- ran logos, over wrote wine log with static value, ran logos again, confirmed static value present in log from previous logos run