### PR TITLE
fix: actually check wineserver

### DIFF
--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -15,7 +15,7 @@ from . import network
 from . import system
 from . import utils
 
-def check_wineserver(app: App):
+def check_wineserver(app: App) -> bool:
     # FIXME: if the wine version changes, we may need to restart the wineserver
     # (or at least kill it). Gotten into several states in dev where this happend
     # Normally when an msi install failed
@@ -24,6 +24,9 @@ def check_wineserver(app: App):
         if not process:
             logging.debug("Failed to spawn wineserver to check it")
             return False
+        # We already check the return code in run_wine_during_install.
+        # If there is a non-zero exit code subprocess.CalledProcessError will be raised
+        return True
     except subprocess.CalledProcessError:
         return False
 
@@ -631,7 +634,10 @@ def run_wine_during_install(
             additional_wine_dll_overrides=additional_wine_dll_overrides
         )
         if process:
-            full_command_string = f"{wine_binary} {exe} {" ".join(exe_args)}"
+            if exe:
+                full_command_string = f"{wine_binary} {exe} {" ".join(exe_args)}"
+            else:
+                full_command_string = f"{wine_binary} {" ".join(exe_args)}"
             logging.debug(f"Waiting on: {full_command_string}")
             process.wait()
             logging.debug(f"Wine process {full_command_string} "


### PR DESCRIPTION
function failed to return anything, causing it to return None which is falsy.

Regressed since 7b8b1cb6cd645d446003cfeb6158e6a3d4b8dca3 causing #396

Also fixed typo in command string generation, as exe can be None

Tested:
- Building dev binary
- Copying to effected VM
- running Logos
- Observe no crash
- Commenting out the changed line
- Building dev binary
- Copying to effected VM
- running Logos
- Observe crash
- Conclusive evidence this one line caused the issue. Probably due to multiple wine servers opening more files than they should have.

Fixes: #396