### PR TITLE
fix: add missing arial font in nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,9 @@
 let
   # We pin to a specific nixpkgs commit for reproducibility.
   # Last updated: 2025-02-10. Check for new commits at https://status.nixos.org.
-  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/a45fa362d887f4d4a7157d95c28ca9ce2899b70e.tar.gz") {};
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/a45fa362d887f4d4a7157d95c28ca9ce2899b70e.tar.gz") {
+    config.allowUnfree = true;
+  };
   unstable_pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/fa35a3c8e17a3de613240fea68f876e5b4896aec.tar.gz") {};
  
 in pkgs.mkShell {
@@ -17,6 +19,7 @@ in pkgs.mkShell {
       requests
       tkinter
     ]))
+    pkgs.corefonts
     unstable_pkgs.wineWowPackages.full
   ];
   shellHook = ''


### PR DESCRIPTION
### Description

Fix `"winetricks -q arial" Failed!` in `Nix/NixOS`. See https://github.com/FaithLife-Community/OuDedetai/issues/387#issuecomment-2780111636.

Need to set `config.allowUnfree = true;` because `corefonts` has unfree license.
