### PR TITLE
feat: always install non-interactively

### DIFF
--- a/io.github.FaithlifeCommunity.OuDedetai.yml
+++ b/io.github.FaithlifeCommunity.OuDedetai.yml
@@ -84,7 +84,7 @@ modules:
           - export TARGETVERSION=10
           # Run Logos after installing since it crashes once while downloading resources.
           # Opening it again recovers
-          - if [ ! -f $XDG_DATA_HOME/${1}Bible10/data/wine64_bottle/drive_c/users/*/AppData/Local/$1/${1}.exe ]; then /app/bin/entrypoint.sh --install-app -y --passive && /app/bin/entrypoint.sh --run-installed-app; fi
+          - if [ ! -f $XDG_DATA_HOME/${1}Bible10/data/wine64_bottle/drive_c/users/*/AppData/Local/$1/${1}.exe ]; then /app/bin/entrypoint.sh --install-app -y && /app/bin/entrypoint.sh --run-installed-app; fi
           - /app/bin/entrypoint.sh --run-installed-app
       # FIXME: Should this pull from github releases?
       - type: file

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -241,7 +241,6 @@ class EphemeralConfiguration:
     terminal_app_prefer_dialog: Optional[bool] = None
 
     # Start of values just set via cli arg
-    faithlife_install_passive: bool = False
     app_run_as_root_permitted: bool = False
     agreed_to_faithlife_terms: bool = False
     """The user expressed clear agreement with faithlife's terms.

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -75,9 +75,12 @@ def get_parser():
         '-L', '--delete-log', action='store_true',
         help='delete the log file',
     )
+    # FIXME: remove this deprecated option.
+    # If we remove this today, scripts using -P will fail, as now it's an "unknown option"
     cfg.add_argument(
         '-P', '--passive', action='store_true',
-        help='run product installer non-interactively. '
+        help='Legacy argument that used to specify to run the product installer non-interactively. '
+        'Now this is the default. '
         'Consider agreeing to the terms as well --i-agree-to-faithlife-terms',
     )
     cfg.add_argument(
@@ -253,9 +256,6 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
 
     if args.assume_yes:
         ephemeral_config.assume_yes = True
-
-    if args.passive or args.assume_yes:
-        ephemeral_config.faithlife_install_passive = True
 
     if args.i_agree_to_faithlife_terms:
         ephemeral_config.agreed_to_faithlife_terms = True

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -399,14 +399,18 @@ def install_msi(app: App):
     wine_binary = app.conf.wine64_binary
     exe_args = ["/i", f"{app.conf.install_dir}/data/{app.conf.faithlife_installer_name}"]
 
-    # Add passive mode if specified
-    if app.conf._overrides.faithlife_install_passive is True:
-        # Ensure the user agrees to the EULA. Exit if they don't.
-        if (
-            app.conf._overrides.agreed_to_faithlife_terms or
-            app.approve_or_exit("Do you agree to Faithlife's EULA? https://faithlife.com/terms")
-        ):
-            exe_args.append("/passive")
+    # Ensure the user agrees to the EULA. Exit if they don't.
+    # This code block tells the MSI installer to run non-interactively.
+    # There have been 2 reports in the wild, once on ctrlalt24's computer and on Itsjoe
+    # where the installer wouldn't launch interactively.
+    # Since the launcher only prompts for EULA, and askes where to install 
+    # (which is pointless as it's in it's own wine prefix), we can just skip the interaction
+    # entirely once we confirm the user has agreed to EULA (for Faithlife's sake)
+    if (
+        app.conf._overrides.agreed_to_faithlife_terms or
+        app.approve_or_exit("Do you agree to Faithlife's EULA? https://faithlife.com/terms")
+    ):
+        exe_args.append("/passive")
 
     # Add MST transform if needed
     release_version = app.conf.installed_faithlife_product_release or app.conf.faithlife_product_release

--- a/tests/manual-testing.md
+++ b/tests/manual-testing.md
@@ -14,7 +14,6 @@
 | `-f/--force-root` | | |
 | `-p/--custom-binary-path` | | |
 | `-L/--delete-log` | `4.0.0-alpha.6` | :+1: |
-| `-P/--passive` | `4.0.0-alpha.6` | :+1: |
 | `--install-app` | `4.0.0-alpha.6` | :+1: |
 | `--run-installed-app` | `4.0.0-alpha.6` | :+1: |
 | `--run-indexing` | | |


### PR DESCRIPTION
This change doesn't show the MSI installer at all, but asks the user to agree to EULA instead

This was done as in extremely rare situations the MSI doesn't launch.

Fixes: #426