### PR TITLE
fix(TUI): show uninstall button if config or install dirs exist

### DIFF
--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -65,8 +65,10 @@ def uninstall(app: App):
     app.status("Uninstalling…")
     delete_paths = [
         app.conf.config_file_path,
-        app.conf.install_dir,
     ]
+    # Only add install_dir if we know what it is
+    if app.conf._raw.install_dir is not None:
+        delete_paths += [app.conf._raw.install_dir]
 
     question = "Are you sure you want to uninstall?"
     context = (

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -1060,8 +1060,11 @@ class TUI(App):
             ]
             labels.extend(labels_catalog)
         
-        # FIXME: #367 rework uninstall to work without a successful install
-        if self.is_installed():
+        if (
+            self.is_installed() 
+            or Path(self.conf.config_file_path).exists() 
+            or (self.conf._raw.install_dir is not None and Path(self.conf._raw.install_dir).exists())
+        ):
             label_user_data_utilities = [
                 "Uninstall"
                 # "Back Up Data",


### PR DESCRIPTION
Tested:
- uninstalled
- created a .json file where the default config path is
- opened TUI to utilities
- found uninstall
- opened utilities again
- uninstall gone
- file deleted

- uninstalled
- Ran: INSTALLDIR=`mktemp -d` python3 -m ou_dedetai.main
- opened TUI to utilities
- found uninstall
- opened utilities again
- uninstall gone
- file deleted

Fixes: #367