### PR TITLE
fix: debian 13 libfuse logic

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -417,11 +417,12 @@ def get_package_manager() -> PackageManager | None:
         query_prefix = '.i  '
         # Set default package list.
         packages = (
-            "libfuse2 "  # appimages
             "binutils wget winbind "  # wine
             "p7zip-full cabextract " # winetricks
             "xdg-utils " # For xdg-mime needed for custom url scheme registration
         )
+
+        # Now set the appimage packages, this has changed over time
         # NOTE: Package names changed together for Ubuntu 24+, Debian 13+, and
         # derivatives. This does not include an exhaustive list of distros that
         # use 'apt', so others will have to be added as users report issues.
@@ -432,13 +433,21 @@ def get_package_manager() -> PackageManager | None:
         # - https://github.com/which-distro/os-release/tree/main
         if (
             (os_name == 'debian' and major_ver >= '13')
-            or (os_name == 'ubuntu' and major_ver >= '24')
+        ):
+            packages += (
+                "libfuse3-4 "  # appimages
+            )
+        elif (
+            (os_name == 'ubuntu' and major_ver >= '24')
             or (os_name == 'linuxmint' and major_ver >= '22')
             or (os_name == 'elementary' and major_ver >= '8')
         ):
-            packages = (
+            packages += (
                 "libfuse3-3 "  # appimages
-                "binutils wget winbind "  # wine
+            )
+        else:
+            packages += (
+                "libfuse2 "  # appimages
             )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('dnf') is not None:  # rhel, fedora


### PR DESCRIPTION
Debian 13 actually uses libfuse3-4 not libfuse 3-3, but all the ubuntu derivatives still use libfuse3-3. Perhaps debian updated from libfuse3-3 to libfuse3-4 at some point and ubuntu hasn't/won't take this change (or yet at least).

Also the old logic doesn't install the other default package list, which it now does

Tested:
- install on debian 12 via cli - observed no failure (I did observe a failure when I tested main)