### PR TITLE
fix: detect chromium and avoid using it

### DIFF
--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -61,7 +61,8 @@ if RUNMODE == 'snap':
 else:
     CACHE_DIR = str(Path(os.getenv('XDG_CACHE_HOME', Path.home() / '.cache' / 'FaithLife-Community'))) 
 
-DATA_HOME = str(Path(os.getenv('XDG_DATA_HOME', str(Path.home() / '.local/share'))) / 'FaithLife-Community') 
+XDG_DATA_HOME = str(Path(os.getenv('XDG_DATA_HOME', str(Path.home() / '.local/share'))))
+DATA_HOME = str(Path(XDG_DATA_HOME)/ 'FaithLife-Community') 
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", "~/.config") + "/FaithLife-Community"
 STATE_DIR = os.getenv("XDG_STATE_HOME", "~/.local/state") + "/FaithLife-Community"
 

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -698,6 +698,87 @@ def enforce_icu_data_files(app: App):
     app.status("ICU files copied.", 100)
 
 
+# https://askubuntu.com/questions/516307/how-do-i-change-default-wine-browser-to-native-ubuntu-browser-instead-of-ie/875347#875347
+def enforce_winebrowser_is_configured(app: App):
+    app.status("Ensuring winebrowser is configured properly…")
+
+    name='set-winebrowser-string.reg'
+    reg_text = r'''REGEDIT4
+
+[HKEY_CURRENT_USER\Software\Wine\WineBrowser]
+"Browsers"="'''
+    # Now check to see if our default browser is chromium or google-chrome - in that case do not use xdg-open,
+    # but use a list of preferred browsers FIRST before xdg-open and warn the user that chromium is presently
+    # unsupported.
+    #
+    # This check is best-effort and may fail if the .desktop entry for chromium uses a naming convention
+    # other than the one used on the debian package.
+
+    # FIXME: #435 Remove this check when the issue is fixed upstream in wine
+    chromium_detected: bool = False
+
+    try:
+        result = system.run_command(
+            "xdg-mime query default x-scheme-handler/https"
+        )
+        if result:
+           command_output: str = result.stdout
+           command_output = command_output.strip().lower()
+
+            # Known chrome .desktops:
+            # chromium_chromium.desktop - Debian Chromium (.deb and snap)
+            # google-chrome and com.google.Chrome.desktop - Debian Google Chrome
+           if (
+               "chromium.desktop" in command_output
+               or "chrome.desktop" in command_output
+           ):
+               chromium_detected = True
+    except subprocess.CalledProcessError as e:
+        logging.warning(
+            "Failed to check if chromium will be used - "
+            "sign in button MAY NOT function if chromium is the default browser. "
+            f"Error was as follows: {e}"
+        )
+
+    browser_list = "firefox,konqueror,mozilla,netscape,galeon,opera,dillo,brave-browser,librewolf"
+
+    if chromium_detected:
+        found_alternative_browser: bool = False
+        # Make sure at least one of the browsers on our list is installed
+        for browser in browser_list.split(","):
+            if shutil.which(browser) is not None:
+                found_alternative_browser = True
+                break
+        
+        if not found_alternative_browser:
+            app.exit(
+                "Failed to find alterative browser (such as firefox) to use rather than Chrome/Chromium. "
+                "Chrome and Chromium presently do not work with {constants.BINARY_NAME} "
+                " (see https://github.com/FaithLife-Community/OuDedetai/issues/435 for more info). "
+                f"Please install one of the following browsers: {browser_list.replace(",",", ")}.",
+            )
+
+        # Do not include xdg-open to prevent chromium from being launched at all.
+        reg_text += f'{browser_list}'
+    else:
+        # FIXME: Add google-chrome and chromium AFTER #435 is fixed
+        reg_text += f'xdg-open,{browser_list}'
+
+    reg_text += '"\n'
+
+    wine_reg_install(app, name, reg_text, app.conf.wine64_binary)
+
+    name='set-http-shell-open.reg'
+    reg_text = r'''REGEDIT4
+
+[HKEY_CLASSES_ROOT\http\shell\open]
+@="C:\\windows\\system32\\winebrowser.exe -nohome "%1""
+
+[HKEY_CLASSES_ROOT\https\shell\open]
+@="C:\\windows\\system32\\winebrowser.exe -nohome "%1""
+'''
+    wine_reg_install(app, name, reg_text, app.conf.wine64_binary)
+
 
 def get_registry_value(reg_path, name, app: App):
     logging.debug(f"Get value for: {reg_path=}; {name=}")


### PR DESCRIPTION
There is presently a wine bug that makes chromium as a browser not work. Detect and remediate.

Also run update-desktop-database after install. Needed for snaps to pickup the new mime type.