### PR TITLE
feat: polish backup/restore guards, sizing, and progress

### DIFF
--- a/ou_dedetai/backup.py
+++ b/ou_dedetai/backup.py
@@ -30,21 +30,39 @@ class BackupBase(abc.ABC):
             # Reset backup dir.
             # The app will re-prompt next time the backup_dir is accessed
             app.conf._raw.backup_dir = None
-        self.backup_dir = Path(self.app.conf.backup_dir).expanduser().resolve()
-        try:
-            self.backup_dir.mkdir(exist_ok=True, parents=True)
-        except PermissionError:
-            m = f"folder not accessible: {self.backup_dir}"
-            if constants.RUNMODE == 'snap':
-                m += f"{m}\n\nTry connecting removable media:\nsnap connect {constants.BINARY_NAME}:removable-media\n"
-            self.app.exit(m)
+        self.backup_dir = self._ensure_backup_dir()
+
+    def _ensure_backup_dir(self) -> Path:
+        """Resolve and create the backups folder, re-prompting if it's gone.
+
+        Handles the case where the configured location (e.g. an external disk)
+        is no longer available, so the user can choose a new one instead of
+        crashing.
+        """
+        last_failed: Optional[Path] = None
+        while True:
+            backup_dir = Path(self.app.conf.backup_dir).expanduser().resolve()
+            try:
+                backup_dir.mkdir(exist_ok=True, parents=True)
+                return backup_dir
+            except (FileNotFoundError, PermissionError) as e:
+                m = f"Backup location not available: {backup_dir} ({e})"
+                if constants.RUNMODE == 'snap':
+                    m += f"\n\nTry connecting removable media:\nsnap connect {constants.BINARY_NAME}:removable-media\n"
+                # Bail out rather than loop forever when we can't re-prompt or
+                # the same location keeps failing.
+                if self.app.conf._overrides.assume_yes or backup_dir == last_failed:
+                    self.app.exit(m)
+                last_failed = backup_dir
+                self.app.info(m)
+                # Forget the bad location so the app re-prompts on next access.
+                self.app.conf._raw.backup_dir = None
 
     def _copy_dirs(
             self,
             src_dirs: List[str|Path] | Tuple[str|Path],
             dst_dir: Path|str,
         ) -> None:
-        # logging.debug("starting _copy_dirs")
         for src in src_dirs:
             if not isinstance(src, Path):
                 src = Path(src)
@@ -61,16 +79,16 @@ class BackupBase(abc.ABC):
         logging.debug(all_backups)
         return all_backups
 
-    def _get_copy_percentage(self) -> int:
+    def _get_copy_progress(self) -> Tuple[int, int]:
+        """Returns (bytes_copied, percent) based on destination disk usage."""
         disk_used = self._get_dest_disk_used()
         # This should already be set by run, but in case it isn't
         if not self.destination_disk_used_init:
             self.destination_disk_used_init = disk_used
 
-        delta = disk_used - self.destination_disk_used_init
-        percent = int(delta * 100 / self.data_size)
-        # logging.debug(f"{percent=}")
-        return percent
+        bytes_copied = max(disk_used - self.destination_disk_used_init, 0)
+        percent = min(int(bytes_copied * 100 / self.data_size), 100)
+        return bytes_copied, percent
 
     def _get_dest_disk_used(self) -> int:
         return shutil.disk_usage(self.destination_dir).used
@@ -96,31 +114,70 @@ class BackupBase(abc.ABC):
             if dst.is_dir():
                 shutil.rmtree(dst)
 
+    def _ensure_not_running(self) -> None:
+        """Offer to stop Logos/indexing if they're running before copying data."""
+        from ou_dedetai.logos import State
+        self.app.logos.monitor()
+        if self.app.logos.indexing_state != State.STOPPED:
+            self.app.approve_or_exit(
+                f"Indexing is running and must stop before {self.mode}. Stop it now?"
+            )
+            self.app.logos.stop_indexing()
+        if self.app.logos.logos_state != State.STOPPED:
+            self.app.approve_or_exit(
+                f"{self.app.conf.faithlife_product} is running and must close before "
+                f"{self.mode}. Close it now?"
+            )
+            self.app.logos.stop()
+
+    def _confirm(self) -> None:
+        """Show human-readable sizes and confirm before copying/overwriting."""
+        dest_existing = utils.get_folder_group_size(
+            [self.destination_dir / d for d in self.DATA_DIRS]
+        )
+        dest_free = shutil.disk_usage(self.destination_dir).free
+        message = (
+            f"About to {self.mode} {utils.format_bytes(self.data_size)} "
+            f"from {self.source_dir} to {self.destination_dir}.\n"
+            f"Destination currently holds {utils.format_bytes(dest_existing)} "
+            f"of data, with {utils.format_bytes(dest_free)} free.\n"
+            "Continue?"
+        )
+        self.app.approve_or_exit(message)
+
     def _run(self) -> None:
-        self.app.status(f"Running {self.mode} from {self.source_dir} to {self.destination_dir}") 
+        self.app.status(f"Running {self.mode} from {self.source_dir} to {self.destination_dir}")
         if self.source_dir is None:
             self.app.exit("source directory not set")
         elif self.destination_dir is None:
             self.app.exit("destination directory not set")
+        self._ensure_not_running()
         src_dirs = self._get_source_subdirs()
 
         self.data_size = self._get_dir_group_size(src_dirs)
-        self._prepare_dest_dir()
-        self.destination_disk_used_init = self._get_dest_disk_used()
         self._verify_disk_space()
-        # logging.debug("starting data copy thread")
+        self._confirm()
+        self._prepare_dest_dir()
+        # Capture the baseline after clearing the destination so copy progress
+        # is measured against what's actually written during this run.
+        self.destination_disk_used_init = self._get_dest_disk_used()
         t = self.app.start_thread(self._copy_dirs, src_dirs, self.destination_dir)
         try:
             while t.is_alive():
-                self.app.status("copying…", self._get_copy_percentage())
+                bytes_copied, percent = self._get_copy_progress()
+                self.app.status(
+                    f"Copying… {percent}% "
+                    f"({utils.format_bytes(bytes_copied)} / "
+                    f"{utils.format_bytes(self.data_size)})",
+                    percent,
+                )
                 time.sleep(0.5)
             print()
         except KeyboardInterrupt:
             print()
             self.app.exit("user cancelled with Ctrl+C.")
         t.join()
-        # logging.debug("finished data copy thread")
-        m = f"Finished {self.mode}. {self.data_size} bytes copied."
+        m = f"Finished {self.mode}. {utils.format_bytes(self.data_size)} copied."
         self.app.status(m)
 
     def _verify_disk_space(self) -> None:

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -267,6 +267,21 @@ def enough_disk_space(dest_dir, bytes_required: int) -> bool:
     return free_bytes > bytes_required
 
 
+def format_bytes(num_bytes: int) -> str:
+    """Format a byte count as a human-readable string (e.g. '4.2 GiB').
+
+    Args:
+        num_bytes: Byte count as a non-negative integer.
+    """
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0 or unit == "TiB":
+            return f"{int(value)} B" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024.0
+    # Unreachable, but keeps type checkers happy
+    return f"{value:.1f} TiB"
+
+
 def get_path_size(file_path: Path|str) -> int:
     file_path = Path(file_path)
     if not file_path.exists():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,6 +255,17 @@ class TestGeneralUtils(unittest.TestCase):
     def test_get_path_size_notexists(self):
         self.assertEqual(0, utils.get_path_size('./no_dir'))
 
+    def test_format_bytes(self):
+        self.assertEqual('0 B', utils.format_bytes(0))
+        self.assertEqual('512 B', utils.format_bytes(512))
+        self.assertEqual('1.0 KiB', utils.format_bytes(1024))
+        self.assertEqual('1.5 KiB', utils.format_bytes(1536))
+        self.assertEqual('1.0 MiB', utils.format_bytes(1024 ** 2))
+        self.assertEqual('2.0 GiB', utils.format_bytes(2 * 1024 ** 3))
+        self.assertEqual('1.0 TiB', utils.format_bytes(1024 ** 4))
+        # Values beyond TiB keep the TiB unit rather than overflowing
+        self.assertEqual('1024.0 TiB', utils.format_bytes(1024 ** 5))
+
     # @unittest.skip("Unused function")
     # def test_get_procs_using_file(self):
     #     with tempfile.TemporaryFile() as tf:


### PR DESCRIPTION
Disclaimer: AI generated- needs human test pass

- Re-prompt for a new backup location instead of crashing when the configured destination is missing/inaccessible (catches both FileNotFoundError and PermissionError; snap removable-media hint).
- Offer to stop a running Logos/indexer before backup/restore.
- Confirm with human-readable sizes (data to copy, existing destination data, free space) before the destructive prepare step.
- Fix progress never updating in the TUI by varying the status message each tick (also shows copied/total sizes); add utils.format_bytes.

Testing done: ruff clean; mypy no new errors; full unittest suite passes (64 pass/16 skip) incl. existing backup tests and new test_format_bytes.

Testing needed: manual run in an installed Logos environment to confirm the missing-disk re-prompt, the running-app guard, the size confirmation, and live progress in the TUI/GUI/CLI frontends.

Fixes: https://github.com/FaithLife-Community/OuDedetai/issues/197 #405 