### PR TITLE
feat: add "Update {product}" to re-run install at latest release

### DIFF
--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -43,6 +43,10 @@ class CLI(App):
         installer.install(self)
         self.exit("Install has finished", intended=True)
 
+    def update_installed_app(self):
+        utils.update_faithlife_product(self)
+        self.exit("Update has finished", intended=True)
+
     def install_dependencies(self):
         utils.install_dependencies(app=self)
 

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -251,6 +251,10 @@ class ControlGui(StatusGui):
         # Install deps button
         self.deps_label = Label(self, text="Install dependencies")
         self.deps_button = Button(self, text="Install")
+        # Update Faithlife product button
+        self.update_product_labelvar = StringVar(value="Update Faithlife Product")
+        self.update_product_label = Label(self, textvariable=self.update_product_labelvar)
+        self.update_product_button = Button(self, text="Update")
         # Backup/restore data buttons
         self.backups_label = Label(self, text="Backup/restore data")
         self.backup_button = Button(self, text="Backup")
@@ -305,6 +309,9 @@ class ControlGui(StatusGui):
         row += 1
         self.deps_label.grid(column=0, row=row, sticky='w', pady=2)
         self.deps_button.grid(column=1, row=row, sticky='w', pady=2)
+        row += 1
+        self.update_product_label.grid(column=0, row=row, sticky='w', pady=2)
+        self.update_product_button.grid(column=1, row=row, sticky='w', pady=2)
         # row += 1
         # self.backups_label.grid(column=0, row=row, sticky='w', pady=2)
         # self.backup_button.grid(column=1, row=row, sticky='w', pady=2)

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -489,6 +489,7 @@ class ControlWindow(GuiApp):
         self.gui.deps_button.config(command=self.install_deps)
         self.gui.backup_button.config(command=self.run_backup)
         self.gui.restore_button.config(command=self.run_restore)
+        self.gui.update_product_button.config(command=self.update_faithlife_product)
         self.gui.update_lli_button.config(
             command=self.update_to_latest_lli_release
         )
@@ -601,6 +602,10 @@ class ControlWindow(GuiApp):
             ],
         )
         return file_path
+
+    def update_faithlife_product(self, evt=None):
+        self.status(f"Updating {self.conf.faithlife_product} to latest release…")
+        self.start_thread(utils.update_faithlife_product, app=self)
 
     def update_to_latest_lli_release(self, evt=None):
         self.status(f"Updating to latest {constants.APP_NAME} version…")
@@ -746,6 +751,9 @@ class ControlWindow(GuiApp):
             self.update_latest_appimage_button()
         except Exception:
             logging.exception("Failed to update appimage button")
+        product = self.conf._raw.faithlife_product
+        if product:
+            self.gui.update_product_labelvar.set(f"Update {product}")
 
 
     def current_logging_state_value(self) -> str:

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -444,6 +444,10 @@ class ControlWindow(GuiApp):
             self.update_latest_lli_release_button()
         self.gui.update_lli_button.state(['disabled'])
         self.start_thread(_update_lli_version)
+
+        if self.conf._raw.faithlife_product:
+            control_gui.update_product_labelvar.set(f"Update {self.conf._raw.faithlife_product}")
+
         # Spawn a thread to ensure our logos state stays up to date
         def _monitor_faithlife_product_pids():
             last_state = copy.copy(self.logos.logos_state)

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -372,7 +372,7 @@ def ensure_product_installed(app: App):
     try:
         installed_release = app.conf.installed_faithlife_product_release
     except Exception:
-        logging.warning("Failed to determine installed version; will install.", exc_info=True)
+        logging.warning("Failed to determine the installed version proceeding with install.", exc_info=True)
         installed_release = None
 
     target_release = app.conf._raw.faithlife_product_release

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -372,7 +372,7 @@ def ensure_product_installed(app: App):
     try:
         installed_release = app.conf.installed_faithlife_product_release
     except Exception:
-        logging.warning("Failed to determine the installed version proceeding with install.", exc_info=True)
+        logging.warning("Failed to determine the installed version. Proceeding with install.", exc_info=True)
         installed_release = None
 
     target_release = app.conf._raw.faithlife_product_release

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -369,13 +369,23 @@ def ensure_product_installed(app: App):
     app.installer_step += 1
     app.status(f"Ensuring {app.conf.faithlife_product} is installed…")
 
-    if not app.is_installed():
+    try:
+        installed_release = app.conf.installed_faithlife_product_release
+    except Exception:
+        logging.warning("Failed to determine installed version; will install.", exc_info=True)
+        installed_release = None
+
+    target_release = app.conf._raw.faithlife_product_release
+
+    if not app.is_installed() or (
+        target_release is not None and installed_release != target_release
+    ):
         # FIXME: Should we try to cleanup on a failed msi?
         # Like terminating msiexec if already running for Logos
         process = wine.install_msi(app)
         if process:
             process.wait()
-    
+
     # Clear installed version cache
     app.conf._installed_faithlife_product_release = None
 

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -112,6 +112,10 @@ def get_parser():
         help='install FaithLife app',
     )
     cmd.add_argument(
+        '--update-installed-app', action='store_true',
+        help='update the installed FaithLife app to the latest release',
+    )
+    cmd.add_argument(
         '--run-installed-app', '-C', action='store_true',
         help='run installed FaithLife app',
     )
@@ -284,6 +288,7 @@ def parse_args(args, parser) -> Tuple[EphemeralConfiguration, Callable[[Ephemera
         'restore',
         'run_indexing',
         'run_installed_app',
+        'update_installed_app',
         'stop_installed_app',
         'set_appimage',
         'toggle_app_logging',
@@ -403,6 +408,7 @@ def run(ephemeral_config: EphemeralConfiguration, action: Callable[[EphemeralCon
         'restore',
         'run_indexing',
         'run_installed_app',
+        'update_installed_app',
         'stop_installed_app',
         'set_appimage',
         'toggle_app_logging',

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -608,6 +608,10 @@ class TUI(App):
             finally:
                 self.conf._overrides.assume_yes = original_assume_yes
                 self.go_to_main_menu()
+        
+        def _update_faithlife_product(app: "TUI"):
+            utils.update_faithlife_product(app)
+            app.go_to_main_menu()
 
         if choice is None or choice == "Exit":
             logging.info("Exiting installation.")
@@ -637,6 +641,9 @@ class TUI(App):
             )
         elif choice.startswith(f"Update {constants.APP_NAME}"):
             utils.update_to_latest_lli_release(self)
+        elif self.conf._raw.faithlife_product and choice == f"Update {self.conf.faithlife_product}":
+            self.reset_screen()
+            self.start_thread(_update_faithlife_product, app=self, daemon_bool=True)
         elif self.conf._raw.faithlife_product and choice == f"Run {self.conf._raw.faithlife_product}": 
             self.reset_screen()
             self.logos.start()
@@ -1002,7 +1009,7 @@ class TUI(App):
                 indexing = "Stop Indexing"
             elif self.logos.indexing_state == logos.State.STOPPED:
                 indexing = "Run Indexing"
-            labels_default = [run, indexing]
+            labels_default = [run, indexing, f"Update {self.conf.faithlife_product}"]
         else:
             labels_default = ["Install", "Advanced Install"]
         labels.extend(labels_default)

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -543,6 +543,18 @@ def update_to_latest_lli_release(app: App):
         logging.debug(f"{constants.APP_NAME} is at a newer version than the latest.") # noqa: 501
 
 
+def update_faithlife_product(app: App):
+    from ou_dedetai import installer  # local import to avoid circular dependency
+    releases = app.conf.faithlife_product_releases
+    if not releases:
+        app.status(f"No releases found for {app.conf.faithlife_product}; cannot update.")
+        return
+    latest = releases[0]  # feed is ordered newest-first
+    app.status(f"Updating {app.conf.faithlife_product} to {latest}…")
+    app.conf.faithlife_product_release = latest
+    installer.install(app)
+
+
 # FIXME: consider moving this to control
 def update_to_latest_recommended_appimage(app: App):
     if app.conf.wine_binary_code not in ["AppImage", "Recommended"]:

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -547,7 +547,7 @@ def update_faithlife_product(app: App):
     from ou_dedetai import installer  # local import to avoid circular dependency
     releases = app.conf.faithlife_product_releases
     if not releases:
-        app.status(f"No releases found for {app.conf.faithlife_product}; cannot update.")
+        app.status(f"No releases were found for {app.conf.faithlife_product}. Refusing to update.")
         return
     latest = releases[0]  # feed is ordered newest-first
     app.status(f"Updating {app.conf.faithlife_product} to {latest}…")


### PR DESCRIPTION
Add a button/menu/CLI entry that updates an installed Logos/Verbum to the latest available release by re-running the install routine.

The install chain is already idempotent except for ensure_product_installed, which skipped the MSI whenever the product exe existed regardless of version. Make that guard version-aware: run the MSI when the exe is missing, the installed release differs from the target, or the installed version can't be determined (deps.json missing/unreadable).

- utils.update_faithlife_product: pin release to the latest, then install()
- installer.ensure_product_installed: version-aware MSI guard
- gui/gui_app: "Update {product}" button wired to the new handler
- tui_app: "Update {product}" main-menu entry when installed
- cli/main: --update-installed-app subcommand (requires app installed)

Testing:
- Installed Logos 47.1, then hit "Update Logos" in the TUI. The main-menu version still showed 47, but after launching Logos and restarting OuDedetai it had updated to 51.1 (latest).
- Ran the update from the GUI while already on 51.1: install statuses cycled on the GUI, the process ran and cleared.
- Ran --update-installed-app from the CLI, same behavior as the GUI.





Fixes: https://github.com/FaithLife-Community/OuDedetai/issues/272 #116 