### PR TITLE
fix: restrict memory from halting system

### DIFF
--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -198,7 +198,12 @@ def ensure_appimage_download(app: App):
     check_system_compatibility(app=app)
     app.installer_step += 1
 
-    if app.conf.faithlife_product_version != '9' and not str(app.conf.wine_binary).lower().endswith('appimage'):
+    if (
+        app.conf.faithlife_product_version != '9'
+        and not str(app.conf.wine_binary).lower().endswith('appimage')
+        and app.conf.wine_binary != constants.WINE_RECOMMENDED_SIGIL
+        and app.conf.wine_binary != constants.WINE_BETA_SIGIL
+    ):
         return
     app.status("Ensuring wine AppImage is downloaded…")
 

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -267,7 +267,9 @@ class LogosManager:
         """Thread target: delegates to MemoryWatchdog and exits the app on a kill."""
         self._memory_watchdog.run()
         if self._memory_watchdog.kill_reason:
-            self.app.exit(self._memory_watchdog.kill_reason)
+            self.app.status(self._memory_watchdog.kill_reason)
+            # We don't want to kill the entire app here - CLI/TUI and GUI each handle when logos terminates differently.
+            # Existing code will already find out that Logos terminated and handle accordinly.
 
     def index(self):
         self.indexing_state = State.STARTING

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -7,6 +7,7 @@ from enum import Enum
 import logging
 import psutil
 import threading
+from typing import Optional
 
 from ou_dedetai import database
 from ou_dedetai.app import App
@@ -32,6 +33,10 @@ class LogosManager:
         """These are sub-processes we started"""
         self.existing_processes: dict[str, list[psutil.Process]] = {}
         """These are processes we discovered already running"""
+        self._memory_watchdog_interval = 2
+        """Seconds between memory checks by the watchdog."""
+        self._memory_watchdog_stop = threading.Event()
+        self._memory_watchdog_thread: Optional[threading.Thread] = None
 
     def monitor_indexing(self):
         if self.app.conf.logos_indexer_exe_windows_path in self.existing_processes:
@@ -132,6 +137,7 @@ class LogosManager:
             wine.wineserver_kill(self.app)
             # Don't send "Running" message to GUI b/c it never clears.
             logging.info(f"Running {self.app.conf.faithlife_product}…")
+            self._ensure_memory_watchdog()
             self.app.start_thread(run_logos, daemon_bool=False)
             # NOTE: The following code would keep the CLI open while running
             # Logos, but since wine logging is sent directly to wine.log,
@@ -237,6 +243,7 @@ class LogosManager:
         # wine.wineserver_wait(self.app)
 
     def end_processes(self):
+        self._memory_watchdog_stop.set()
         for process_name, process in self.processes.items():
             if isinstance(process, subprocess.Popen):
                 logging.debug(f"Found {process_name} in Processes. Attempting to close {process}.")
@@ -246,6 +253,60 @@ class LogosManager:
                 except subprocess.TimeoutExpired:
                     os.killpg(process.pid, signal.SIGTERM)
                     os.waitpid(-process.pid, 0)
+
+    def _ensure_memory_watchdog(self):
+        """Starts the memory watchdog thread if it isn't already running."""
+        if (
+            self._memory_watchdog_thread is not None
+            and self._memory_watchdog_thread.is_alive()
+        ):
+            return
+        self._memory_watchdog_stop.clear()
+        self._memory_watchdog_thread = self.app.start_thread(self._memory_watchdog)
+
+    def _memory_watchdog(self):
+        """Hard-kills a tracked Wine/Logos process whose resident memory grows
+        past 90% of currently-available system RAM, so a runaway process (e.g.
+        the indexer) can't exhaust the host.
+
+        Resident (not virtual) memory is used deliberately: Wine reserves a huge
+        virtual address space, so a virtual-memory cap would refuse to start it.
+        """
+        while not self._memory_watchdog_stop.wait(self._memory_watchdog_interval):
+            if not self.processes:
+                continue
+            for name, process in list(self.processes.items()):
+                if not isinstance(process, subprocess.Popen) or process.poll() is not None:
+                    continue
+                try:
+                    rss = system.get_process_tree_rss(process.pid)
+                except psutil.NoSuchProcess:
+                    continue
+                # The cap is 90% of the memory free of this process, so its own
+                # usage isn't counted against its budget as it grows.
+                cap = system.get_memory_cap(rss)
+                if rss > cap:
+                    display = name.replace('\\', '/').rstrip('/').rsplit('/', 1)[-1]
+                    logging.warning(
+                        f"{display} exceeded the memory cap "
+                        f"({rss // 1024 // 1024} MB > {cap // 1024 // 1024} MB); "
+                        "terminating it."
+                    )
+                    self._hard_kill(process)
+                    self.app.exit(f"{display} used too much memory and was stopped.")
+
+    def _hard_kill(self, process: subprocess.Popen):
+        """Terminates a process group, escalating to SIGKILL after a grace."""
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        except ProcessLookupError:
+            pass
 
     def index(self):
         self.indexing_state = State.STARTING
@@ -287,6 +348,7 @@ class LogosManager:
 
         wine.wineserver_kill(self.app)
         self.app.status("Indexing has begun…", 0)
+        self._ensure_memory_watchdog()
         index_thread = self.app.start_thread(run_indexing, daemon_bool=False)
         self.indexing_state = State.RUNNING
         self.app.start_thread(

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from ou_dedetai import database
 from ou_dedetai.app import App
+from ou_dedetai.watchdog import MemoryWatchdog
 
 from . import system
 from . import utils
@@ -33,9 +34,7 @@ class LogosManager:
         """These are sub-processes we started"""
         self.existing_processes: dict[str, list[psutil.Process]] = {}
         """These are processes we discovered already running"""
-        self._memory_watchdog_interval = 2
-        """Seconds between memory checks by the watchdog."""
-        self._memory_watchdog_stop = threading.Event()
+        self._memory_watchdog = MemoryWatchdog(self.processes)
         self._memory_watchdog_thread: Optional[threading.Thread] = None
 
     def monitor_indexing(self):
@@ -243,7 +242,7 @@ class LogosManager:
         # wine.wineserver_wait(self.app)
 
     def end_processes(self):
-        self._memory_watchdog_stop.set()
+        self._memory_watchdog.stop()
         for process_name, process in self.processes.items():
             if isinstance(process, subprocess.Popen):
                 logging.debug(f"Found {process_name} in Processes. Attempting to close {process}.")
@@ -261,52 +260,14 @@ class LogosManager:
             and self._memory_watchdog_thread.is_alive()
         ):
             return
-        self._memory_watchdog_stop.clear()
-        self._memory_watchdog_thread = self.app.start_thread(self._memory_watchdog)
+        self._memory_watchdog.reset()
+        self._memory_watchdog_thread = self.app.start_thread(self._run_watchdog)
 
-    def _memory_watchdog(self):
-        """Hard-kills a tracked Wine/Logos process whose resident memory grows
-        past 90% of currently-available system RAM, so a runaway process (e.g.
-        the indexer) can't exhaust the host.
-
-        Resident (not virtual) memory is used deliberately: Wine reserves a huge
-        virtual address space, so a virtual-memory cap would refuse to start it.
-        """
-        while not self._memory_watchdog_stop.wait(self._memory_watchdog_interval):
-            if not self.processes:
-                continue
-            for name, process in list(self.processes.items()):
-                if not isinstance(process, subprocess.Popen) or process.poll() is not None:
-                    continue
-                try:
-                    rss = system.get_process_tree_rss(process.pid)
-                except psutil.NoSuchProcess:
-                    continue
-                # The cap is 90% of the memory free of this process, so its own
-                # usage isn't counted against its budget as it grows.
-                cap = system.get_memory_cap(rss)
-                if rss > cap:
-                    display = name.replace('\\', '/').rstrip('/').rsplit('/', 1)[-1]
-                    logging.warning(
-                        f"{display} exceeded the memory cap "
-                        f"({rss // 1024 // 1024} MB > {cap // 1024 // 1024} MB); "
-                        "terminating it."
-                    )
-                    self._hard_kill(process)
-                    self.app.exit(f"{display} used too much memory and was stopped.")
-
-    def _hard_kill(self, process: subprocess.Popen):
-        """Terminates a process group, escalating to SIGKILL after a grace."""
-        try:
-            os.killpg(process.pid, signal.SIGTERM)
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-        except ProcessLookupError:
-            pass
+    def _run_watchdog(self):
+        """Thread target: delegates to MemoryWatchdog and exits the app on a kill."""
+        self._memory_watchdog.run()
+        if self._memory_watchdog.kill_reason:
+            self.app.exit(self._memory_watchdog.kill_reason)
 
     def index(self):
         self.indexing_state = State.STARTING

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -238,6 +238,91 @@ def get_pids(query) -> list[psutil.Process]:
     return results
 
 
+MEMORY_CAP_FRACTION = 0.9
+"""Fraction of available system memory a spawned process is allowed to use."""
+
+
+def get_memory_cap(process_rss: int = 0, fraction: float = MEMORY_CAP_FRACTION) -> int:
+    """Resident-memory ceiling (bytes) a spawned process is allowed to use.
+
+    Defined as a fraction (default 90%) of the memory that would be available if
+    the process weren't running: current available memory *plus* the process's
+    own resident usage (``process_rss``). Adding the process's own usage back is
+    what keeps the cap stable as the process grows — only *other* processes'
+    memory use should move its ceiling, not its own.
+
+    On Linux ``psutil.virtual_memory().available`` is a single read+parse of
+    ``/proc/meminfo`` (the kernel's ``MemAvailable``), so it's cheap enough to
+    recompute on every check rather than caching a spawn-time snapshot.
+    """
+    available = psutil.virtual_memory().available + process_rss
+    return int(available * fraction)
+
+
+def get_process_tree_rss(pid: int) -> int:
+    """Total resident set size (bytes) of a process and all its descendants.
+
+    Wine spawns helper processes, so the whole tree must be summed to know how
+    much memory the launched application is really using.
+    """
+    proc = psutil.Process(pid)
+    processes = [proc]
+    try:
+        processes.extend(proc.children(recursive=True))
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        pass
+    total = 0
+    for p in processes:
+        try:
+            total += p.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            pass
+    return total
+
+
+_systemd_run_usable: Optional[bool] = None
+
+
+def _can_use_systemd_run() -> bool:
+    """Return True if systemd-run can create a user scope on this host.
+
+    Checks that the binary exists *and* that a real user manager / D-Bus session
+    is available. Result is cached after the first call.
+    """
+    global _systemd_run_usable
+    if _systemd_run_usable is not None:
+        return _systemd_run_usable
+    if not shutil.which('systemd-run'):
+        _systemd_run_usable = False
+        return False
+    try:
+        result = subprocess.run(
+            ['systemd-run', '--user', '--scope', '--quiet', '--collect', '--', 'true'],
+            capture_output=True,
+            timeout=5,
+        )
+        _systemd_run_usable = result.returncode == 0
+    except Exception:
+        _systemd_run_usable = False
+    return _systemd_run_usable
+
+
+def systemd_run_memory_prefix(cap_bytes: int) -> list[str]:
+    """Return the systemd-run arg list to wrap a command in a memory-capped scope.
+
+    Returns an empty list when systemd-run is not usable, so callers can simply
+    prepend the result unconditionally. The list ends with '--' to separate
+    systemd-run options from the wrapped command.
+    """
+    if not _can_use_systemd_run():
+        return []
+    return [
+        'systemd-run', '--user', '--scope', '--quiet', '--collect',
+        f'-p', f'MemoryMax={cap_bytes}',
+        '--',
+    ]
+
+
 def reboot(superuser_command: str):
     logging.info("Rebooting system.")
     command = f"{superuser_command} reboot now"

--- a/ou_dedetai/watchdog.py
+++ b/ou_dedetai/watchdog.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import signal
+import subprocess
+import threading
+from typing import Optional
+
+import psutil
+
+from ou_dedetai import system
+
+
+class MemoryWatchdog:
+    """Polls the RSS of tracked Wine/Logos subprocesses and hard-kills any that
+    exceed 90% of currently-available system RAM.
+
+    Has no reference to App — callers (LogosManager) read kill_reason after
+    run() returns and decide how to surface the event.
+    """
+
+    def __init__(self, processes: dict, interval: float = 2):
+        self._processes = processes
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self.kill_reason: Optional[str] = None
+
+    def stop(self):
+        self._stop_event.set()
+
+    def reset(self):
+        self._stop_event.clear()
+        self.kill_reason = None
+
+    def run(self):
+        """Blocking loop. Returns when stopped cleanly or after killing a process."""
+        while not self._stop_event.wait(self._interval):
+            for name, process in list(self._processes.items()):
+                if not isinstance(process, subprocess.Popen) or process.poll() is not None:
+                    continue
+                try:
+                    rss = system.get_process_tree_rss(process.pid)
+                except psutil.NoSuchProcess:
+                    continue
+                # Cap is 90% of memory free of this process so its own growing
+                # footprint is never counted against its budget.
+                cap = system.get_memory_cap(rss)
+                if rss > cap:
+                    display = name.replace('\\', '/').rstrip('/').rsplit('/', 1)[-1]
+                    logging.warning(
+                        f"{display} exceeded the memory cap "
+                        f"({rss // 1024 // 1024} MB > {cap // 1024 // 1024} MB); "
+                        "terminating it."
+                    )
+                    self._hard_kill(process)
+                    self.kill_reason = f"{display} used too much memory and was stopped."
+                    return
+
+    def _hard_kill(self, process: subprocess.Popen):
+        """Terminates a process group, escalating to SIGKILL after a grace period."""
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        except ProcessLookupError:
+            pass

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -560,6 +560,9 @@ def run_wine_process(
     if exe_args:
         command.extend(exe_args)
 
+    prefix = system.systemd_run_memory_prefix(system.get_memory_cap())
+    command = prefix + command
+
     cmd = f"Running wine cmd: '{' '.join(command)}'"
     logging.debug(cmd)
     try:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -78,5 +78,55 @@ class TestMemoryLimits(unittest.TestCase):
             child.stdout.close()
 
 
+class TestSystemdRunPrefix(unittest.TestCase):
+    """Covers systemd_run_memory_prefix() and _can_use_systemd_run()."""
+
+    def setUp(self):
+        # Reset the module-level cache between tests.
+        system._systemd_run_usable = None
+
+    def tearDown(self):
+        system._systemd_run_usable = None
+
+    def test_returns_empty_when_not_usable(self):
+        with patch('ou_dedetai.system._can_use_systemd_run', return_value=False):
+            self.assertEqual(system.systemd_run_memory_prefix(1024), [])
+
+    def test_returns_prefix_when_usable(self):
+        with patch('ou_dedetai.system._can_use_systemd_run', return_value=True):
+            prefix = system.systemd_run_memory_prefix(2 * 1024 * 1024 * 1024)
+        self.assertIn('systemd-run', prefix)
+        self.assertIn('--user', prefix)
+        self.assertIn('--scope', prefix)
+        self.assertIn('--', prefix)
+        # MemoryMax must be present with the exact byte value, no swap limit.
+        self.assertIn(f'MemoryMax={2 * 1024 * 1024 * 1024}', ' '.join(prefix))
+        self.assertNotIn('MemorySwapMax', ' '.join(prefix))
+
+    def test_prefix_ends_with_separator(self):
+        with patch('ou_dedetai.system._can_use_systemd_run', return_value=True):
+            prefix = system.systemd_run_memory_prefix(512)
+        self.assertEqual(prefix[-1], '--')
+
+    def test_can_use_systemd_run_false_when_binary_missing(self):
+        with patch('ou_dedetai.system.shutil.which', return_value=None):
+            self.assertFalse(system._can_use_systemd_run())
+
+    def test_can_use_systemd_run_false_when_probe_fails(self):
+        with patch('ou_dedetai.system.shutil.which', return_value='/usr/bin/systemd-run'):
+            with patch('ou_dedetai.system.subprocess.run') as mock_run:
+                mock_run.return_value = Mock(returncode=1)
+                self.assertFalse(system._can_use_systemd_run())
+
+    def test_can_use_systemd_run_caches_result(self):
+        with patch('ou_dedetai.system.shutil.which', return_value='/usr/bin/systemd-run'):
+            with patch('ou_dedetai.system.subprocess.run') as mock_run:
+                mock_run.return_value = Mock(returncode=0)
+                system._can_use_systemd_run()
+                system._can_use_systemd_run()
+                # Probe subprocess should only run once.
+                self.assertEqual(mock_run.call_count, 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import ou_dedetai.system as system
+
+
+class TestMemoryLimits(unittest.TestCase):
+    """Covers the per-process memory-watchdog helpers in system.py."""
+
+    def test_get_memory_cap_default_fraction(self):
+        with patch('ou_dedetai.system.psutil.virtual_memory') as vmem:
+            vmem.return_value = Mock(available=1000)
+            # Default fraction is 90% of available memory.
+            self.assertEqual(system.get_memory_cap(), 900)
+
+    def test_get_memory_cap_custom_fraction(self):
+        with patch('ou_dedetai.system.psutil.virtual_memory') as vmem:
+            vmem.return_value = Mock(available=1000)
+            self.assertEqual(system.get_memory_cap(fraction=0.5), 500)
+
+    def test_get_memory_cap_excludes_process_rss(self):
+        with patch('ou_dedetai.system.psutil.virtual_memory') as vmem:
+            vmem.return_value = Mock(available=1000)
+            # The process's own usage is added back before applying the fraction,
+            # so its own memory doesn't count against its budget:
+            # 0.9 * (1000 + 500) = 1350.
+            self.assertEqual(system.get_memory_cap(process_rss=500), 1350)
+
+    def test_get_memory_cap_returns_int(self):
+        with patch('ou_dedetai.system.psutil.virtual_memory') as vmem:
+            # Fractions that don't divide evenly must still yield an int (bytes).
+            vmem.return_value = Mock(available=1001)
+            cap = system.get_memory_cap()
+            self.assertIsInstance(cap, int)
+            self.assertEqual(cap, 900)
+
+    def test_get_process_tree_rss_positive(self):
+        # The current process is using some resident memory.
+        self.assertGreater(system.get_process_tree_rss(os.getpid()), 0)
+
+    def test_get_process_tree_rss_missing_pid(self):
+        # A pid that doesn't exist should raise NoSuchProcess (caller handles it).
+        import psutil
+        # PID 0 is the scheduler and not a real selectable process.
+        with self.assertRaises(psutil.Error):
+            system.get_process_tree_rss(2 ** 31 - 1)
+
+    def test_get_process_tree_rss_includes_children(self):
+        # Spawn a child that allocates and touches ~100 MB, then confirm the
+        # tree RSS of *this* process reflects the child's resident memory.
+        # This mirrors the synthetic-hog validation of the watchdog kill path.
+        baseline = system.get_process_tree_rss(os.getpid())
+        hog = (
+            "import sys, time\n"
+            "buf = bytearray(100 * 1024 * 1024)\n"
+            "for i in range(0, len(buf), 4096):\n"  # touch every page so it's resident
+            "    buf[i] = 1\n"
+            "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+            "time.sleep(30)\n"
+        )
+        child = subprocess.Popen(
+            [sys.executable, '-c', hog],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            # Wait until the child reports it has finished allocating.
+            self.assertEqual(child.stdout.readline().strip(), 'ready')
+            with_child = system.get_process_tree_rss(os.getpid())
+            # The tree (which now includes the child) grew by most of the 100 MB.
+            self.assertGreater(with_child - baseline, 50 * 1024 * 1024)
+        finally:
+            child.kill()
+            child.wait()
+            child.stdout.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,179 @@
+import os
+import signal
+import subprocess
+import sys
+import threading
+import unittest
+from unittest.mock import Mock, call, patch
+
+import psutil
+
+import ou_dedetai.system as system
+from ou_dedetai.watchdog import MemoryWatchdog
+
+
+def _baseline_python_rss() -> int:
+    """Return the RSS of a freshly-started, idle Python interpreter.
+
+    The probe process writes 'ready' before performing any user-space
+    allocation so the measurement reflects interpreter startup overhead only.
+    """
+    probe = subprocess.Popen(
+        [sys.executable, '-c',
+         "import sys, time\n"
+         "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+         "time.sleep(30)\n"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert probe.stdout.readline().strip() == 'ready'
+        return system.get_process_tree_rss(probe.pid)
+    finally:
+        probe.kill()
+        probe.wait()
+        probe.stdout.close()
+
+
+class TestMemoryWatchdogKill(unittest.TestCase):
+    """Integration test: real subprocess, patched cap, real kill."""
+
+    def test_watchdog_kills_over_limit_process(self):
+        baseline_rss = _baseline_python_rss()
+
+        # Child: signal ready (pre-allocation), allocate 50 MB touching every
+        # page, signal allocated, then sleep.
+        alloc_script = (
+            "import sys, time\n"
+            "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+            "buf = bytearray(50 * 1024 * 1024)\n"
+            "for i in range(0, len(buf), 4096):\n"
+            "    buf[i] = 1\n"
+            "sys.stdout.write('allocated\\n'); sys.stdout.flush()\n"
+            "time.sleep(30)\n"
+        )
+        child = subprocess.Popen(
+            [sys.executable, '-c', alloc_script],
+            stdout=subprocess.PIPE,
+            text=True,
+            # new process group so _hard_kill's killpg targets only the child
+            start_new_session=True,
+        )
+        try:
+            self.assertEqual(child.stdout.readline().strip(), 'ready')
+            self.assertEqual(child.stdout.readline().strip(), 'allocated')
+
+            # Cap is just above the empty-interpreter baseline — well below the
+            # child's actual RSS after allocation.
+            cap = baseline_rss + 1
+
+            processes = {'test_child': child}
+            watchdog = MemoryWatchdog(processes, interval=0.05)
+
+            with patch('ou_dedetai.watchdog.system.get_memory_cap', return_value=cap):
+                t = threading.Thread(target=watchdog.run, daemon=True)
+                t.start()
+                t.join(timeout=5)
+
+            self.assertFalse(t.is_alive(), "watchdog thread should have exited after kill")
+            self.assertIsNotNone(child.poll(), "child process should have been killed")
+            self.assertIsNotNone(watchdog.kill_reason)
+        finally:
+            if child.poll() is None:
+                child.kill()
+            child.wait()
+            child.stdout.close()
+
+
+class TestMemoryWatchdogLogic(unittest.TestCase):
+    """Unit tests for watchdog loop behaviour using mocks."""
+
+    def _make_mock_popen(self, poll_return=None, pid=None):
+        mock = Mock(spec=subprocess.Popen)
+        mock.poll.return_value = poll_return
+        mock.pid = pid if pid is not None else os.getpid()
+        return mock
+
+    def test_watchdog_skips_already_dead_process(self):
+        dead = self._make_mock_popen(poll_return=0)
+        processes = {'dead': dead}
+        watchdog = MemoryWatchdog(processes, interval=0.05)
+
+        # Stop immediately so the loop runs at most one iteration.
+        watchdog.stop()
+        watchdog.run()
+
+        self.assertIsNone(watchdog.kill_reason)
+
+    def test_watchdog_skips_no_such_process(self):
+        alive = self._make_mock_popen(poll_return=None)
+        processes = {'alive': alive}
+        watchdog = MemoryWatchdog(processes, interval=0.05)
+
+        with patch('ou_dedetai.watchdog.system.get_process_tree_rss',
+                   side_effect=psutil.NoSuchProcess(pid=0)):
+            watchdog.stop()
+            watchdog.run()
+
+        self.assertIsNone(watchdog.kill_reason)
+
+    def test_watchdog_skips_non_popen_entry(self):
+        processes = {'not_a_popen': object()}
+        watchdog = MemoryWatchdog(processes, interval=0.05)
+        watchdog.stop()
+        watchdog.run()
+        self.assertIsNone(watchdog.kill_reason)
+
+    def test_stop_exits_loop(self):
+        watchdog = MemoryWatchdog({}, interval=0.05)
+        t = threading.Thread(target=watchdog.run, daemon=True)
+        t.start()
+        watchdog.stop()
+        t.join(timeout=2)
+        self.assertFalse(t.is_alive())
+
+    def test_reset_clears_state(self):
+        watchdog = MemoryWatchdog({}, interval=0.05)
+        watchdog.kill_reason = "something"
+        watchdog._stop_event.set()
+
+        watchdog.reset()
+
+        self.assertIsNone(watchdog.kill_reason)
+        self.assertFalse(watchdog._stop_event.is_set())
+
+
+class TestHardKill(unittest.TestCase):
+    """Unit tests for _hard_kill SIGTERM/SIGKILL escalation."""
+
+    def _watchdog(self):
+        return MemoryWatchdog({})
+
+    def test_hard_kill_sigterm_success(self):
+        mock_process = Mock(spec=subprocess.Popen)
+        mock_process.pid = os.getpid()
+        mock_process.wait.return_value = None
+
+        with patch('ou_dedetai.watchdog.os.killpg') as mock_killpg:
+            self._watchdog()._hard_kill(mock_process)
+
+        calls = mock_killpg.call_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0], call(mock_process.pid, signal.SIGTERM))
+
+    def test_hard_kill_escalates_to_sigkill(self):
+        mock_process = Mock(spec=subprocess.Popen)
+        mock_process.pid = os.getpid()
+        mock_process.wait.side_effect = subprocess.TimeoutExpired(cmd='', timeout=10)
+
+        with patch('ou_dedetai.watchdog.os.killpg') as mock_killpg:
+            self._watchdog()._hard_kill(mock_process)
+
+        calls = mock_killpg.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], call(mock_process.pid, signal.SIGTERM))
+        self.assertEqual(calls[1], call(mock_process.pid, signal.SIGKILL))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Two-layer memory protection prevents a runaway Wine/Logos process (e.g.
the indexer) from exhausting the host.

Primary – systemd-run cgroup enforcement:
When systemd-run is available, wine commands are wrapped in a transient
user scope with MemoryMax set to 90% of currently-available RAM. The
kernel enforces the limit at the cgroup level with no polling overhead.
Availability is probed once at runtime and cached.

Fallback – Python RSS watchdog:
A background thread (LogosManager._memory_watchdog) polls the resident
set size of the entire Wine process tree every two seconds. The cap is
90% of the RAM that would be free if the monitored process were not
running (available + process_rss), so the process's own growing
footprint is never counted against its budget — only other processes
can move the ceiling. If the cap is exceeded, the process group is
SIGTERM'd with a 10-second grace period before escalating to SIGKILL.

The watchdog starts when Logos launches or indexing begins, and is
stopped cleanly by end_processes(). Also fixes the AppImage download
gate to skip the download when the wine binary is set to a recommended
or beta sigil.

Tested:
- systemd-run cgroup path: Logos launched successfully inside a
  run-*.scope with MemoryMax=1612958515 (~90% of available RAM at
  launch). Scope appeared in `systemctl --user list-units --type=scope`.
- Fallback path: after removing the systemd-run binary, no scope was
  created and Wine launched unwrapped; watchdog remains the sole enforcer.
- Unit tests (13/13): all TestMemoryLimits and TestSystemdRunPrefix
  cases pass.
- Polling watchdog kill path: NOT yet tested end-to-end (no spike test
  run against a live process).
- Unittests on the polling watchdog as written

Have not tested with a real Logos installation - only mock tests. Mostly AI written tests. Would be wise to test manually if we know how to make the memory footprint trigger a crash

Fixes: #457 