### PR TITLE
fix: clear out version

### DIFF
--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -380,13 +380,13 @@ def ensure_product_installed(app: App):
     if not app.is_installed() or (
         target_release is not None and installed_release != target_release
     ):
-        # Clear out the stale cache before installing the MSI so the new value can be retrieved
-        app.conf._installed_faithlife_product_release = None
         # FIXME: Should we try to cleanup on a failed msi?
         # Like terminating msiexec if already running for Logos
         process = wine.install_msi(app)
         if process:
             process.wait()
+        # Clear out the stale cache after installing the MSI so the new value can be retrieved
+        app.conf._installed_faithlife_product_release = None
 
     # Clear installed version cache
     app.conf._installed_faithlife_product_release = None

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -380,6 +380,8 @@ def ensure_product_installed(app: App):
     if not app.is_installed() or (
         target_release is not None and installed_release != target_release
     ):
+        # Clear out the stale cache before installing the MSI so the new value can be retrieved
+        app.conf._installed_faithlife_product_release = None
         # FIXME: Should we try to cleanup on a failed msi?
         # Like terminating msiexec if already running for Logos
         process = wine.install_msi(app)


### PR DESCRIPTION
Tested:
- installed 47
- close and reopen OD
- Logos version empty
- open logos for first time
- close and reopen OD
- version shows up
- close logos
- update logos
- still shows old version
- close and reopen OD
- still shows old version
- run logos
- close and reopen OD

Rejected

Fixes: #477 