### PR TITLE
fix: don't show update button when it isn't needed

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -725,6 +725,25 @@ class Config:
         options = self.faithlife_product_releases
         return self._ask_if_not_found("faithlife_product_release", question, options)
 
+    @property
+    def is_installed_faithlife_product_release_latest(self) -> Optional[bool]:
+        releases = self.faithlife_product_releases
+        if not releases:
+            # We didn't get any releases back. Strange.
+            logging.debug("No faithlife releases on the given channel.")
+            return None
+        installed = self.installed_faithlife_product_release
+        if installed is None:
+            return None
+        # Now unfortunately the format differs between the releases and the installed one
+        # the releases has it in the form 51.1.0.0003 (notice the padded 0 on the build number)
+        # While the installed version has it in the form 51.1.0.3
+        # Normalize both to tuples of ints so the padding doesn't matter.
+        def _normalize(version: str) -> tuple[int, ...]:
+            return tuple(int(part) for part in version.split("."))
+
+        return _normalize(releases[0]) == _normalize(installed)
+
     @faithlife_product_release.setter
     def faithlife_product_release(self, value: Optional[str]):
         if self._raw.faithlife_product_release != value:

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -702,6 +702,21 @@ class ControlWindow(GuiApp):
                 self.gui.app_button.state(['disabled'])
                 self.gui.app_install_advanced.state(['disabled'])
 
+    def update_product_button(self, evt=None):
+        msg = None
+        if not self.is_installed():
+            state = 'disabled'
+            msg = "This button is disabled. Please install first."
+        elif self.conf.is_installed_faithlife_product_release_latest:
+            state = 'disabled'
+            msg = f"This button is disabled. {self.conf.faithlife_product} is up-to-date."
+        else:
+            state = '!disabled'
+        if msg:
+            gui.ToolTip(self.gui.update_product_button, msg)
+        self.clear_status()
+        self.gui.update_product_button.state([state])
+
     def update_latest_lli_release_button(self, evt=None):
         msg = None
         result = utils.compare_logos_linux_installer_version(self)
@@ -767,6 +782,10 @@ class ControlWindow(GuiApp):
             self.update_latest_appimage_button()
         except Exception:
             logging.exception("Failed to update appimage button")
+        try:
+            self.update_product_button()
+        except Exception:
+            logging.exception("Failed to update product button")
         product = self.conf._raw.faithlife_product
         if product:
             self.gui.update_product_labelvar.set(f"Update {product}")

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -1039,7 +1039,12 @@ class TUI(App):
                 indexing = "Stop Indexing"
             elif self.logos.indexing_state == logos.State.STOPPED:
                 indexing = "Run Indexing"
-            labels_default = [run, indexing, f"Update {self.conf.faithlife_product}"]
+            labels_default = [run, indexing]
+
+            # This request goes out to the internet but uses the cache.
+            # May slow TUI responsiveness on open on very slow ping networks
+            if not self.conf.is_installed_faithlife_product_release_latest:
+                labels_default.append(f"Update {self.conf.faithlife_product}")
         else:
             labels_default = ["Install", "Advanced Install"]
         labels.extend(labels_default)


### PR DESCRIPTION
Downside of this is it makes an additional network call on the main TUI page - which we had only one before for the other update button

On the GUI this network check is done on a separate thread in order to not halt the main body

Fixes: 478