### PR TITLE
feat: keep track of network failures

### DIFF
--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -53,6 +53,9 @@ MATRIX_LINK = "https://matrix.to/#/#logosbible:matrix.org"
 CACHE_LIFETIME_HOURS = 12
 """How long to wait before considering our version cache invalid"""
 
+NETWORK_OFFLINE_TTL_SECONDS = 120
+"""How long subsequent network requests are short-circuited after a failure."""
+
 if RUNMODE == 'snap':
     _snap_user_common = os.getenv('SNAP_USER_COMMON')
     if _snap_user_common is None:

--- a/ou_dedetai/network.py
+++ b/ou_dedetai/network.py
@@ -1,5 +1,6 @@
 import abc
 from dataclasses import dataclass, field
+import functools
 import hashlib
 import json
 import logging
@@ -22,6 +23,36 @@ from ou_dedetai.app import App
 
 from . import constants
 from . import utils
+
+
+class NetworkOffline(requests.exceptions.ConnectionError):
+    """Raised when a network call fails and the instance is marked offline.
+
+    Subsequent calls are short-circuited for NETWORK_OFFLINE_TTL_SECONDS.
+    Subclasses ConnectionError so existing broad `except` blocks catch it.
+    """
+
+    def __init__(self, message: str = "Network is offline.") -> None:
+        super().__init__(message)
+
+
+def offline_aware(method: Callable) -> Callable:
+    """Decorator for NetworkRequests methods that make network calls.
+
+    Short-circuits if the instance is already offline; on ConnectionError or
+    Timeout, marks the instance offline and raises NetworkOffline.
+    """
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if self.is_offline:
+            raise NetworkOffline()
+        try:
+            return method(self, *args, **kwargs)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            self._offline_until = time.monotonic() + constants.NETWORK_OFFLINE_TTL_SECONDS
+            raise NetworkOffline() from e
+    return wrapper
+
 
 class Props(abc.ABC):
     def __init__(self) -> None:
@@ -249,6 +280,15 @@ class NetworkRequests:
     ) -> None:
         self._cache = CachedRequests.load().ensure_fresh(force=force_clean or False)
         self._cache._update_hook = hook
+        self._offline_until: Optional[float] = None
+
+    @property
+    def is_offline(self) -> bool:
+        if self._offline_until is None:
+            return False
+        if time.monotonic() >= self._offline_until:
+            return False
+        return True
 
     def _faithlife_product_releases(
         self,
@@ -270,6 +310,7 @@ class NetworkRequests:
             return None
         return releases[product][version][channel]
 
+    @offline_aware
     def faithlife_product_releases(
         self,
         product: str,
@@ -292,10 +333,11 @@ class NetworkRequests:
         repo = "FaithLife-Community/wine-appimages"
         return self._repo_version(repo)
 
+    @offline_aware
     def _url_size_and_hash(self, url: str) -> tuple[Optional[int], Optional[str]]:
         """Attempts to get the size and hash from a URL.
         Uses cache if it exists
-        
+
         Returns:
             bytes - from the Content-Length leader
             md5_hash - from the Content-MD5 header or S3's etag
@@ -312,6 +354,7 @@ class NetworkRequests:
     def url_md5(self, url: str) -> Optional[str]:
         return self._url_size_and_hash(url)[1]
 
+    @offline_aware
     def _repo_version(self, repository: str) -> GithubSoftwareReleasesInfo:
         output = GithubSoftwareReleasesInfo(latest=None, pre_release=None)
         if (
@@ -344,6 +387,7 @@ class NetworkRequests:
         return output
             
 
+    @offline_aware
     def _repo_latest_version(self, repository: str) -> SoftwareReleaseInfo:
         if (
             repository not in self._cache.repository_latest_version
@@ -547,15 +591,15 @@ def _net_get(url: str, target: Optional[Path]=None, app: Optional[App] = None):
                                         f"Downloading {target_props.path.name}…",
                                         percent
                                     )
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.HTTPError as e:
             # If this was an incomplete read try again
             new_size = FileProps(target).size
             if (
                 total_size is not None
                 and new_size is not None
-                and new_size < total_size 
+                and new_size < total_size
                 and (
-                    last_size is None 
+                    last_size is None
                     or new_size > last_size
                 )
             ):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,7 +1,11 @@
 import tempfile
+import time
 import unittest
+import unittest.mock
 from pathlib import Path
-from requests.exceptions import MissingSchema
+from requests.exceptions import ConnectionError as RequestsConnectionError, MissingSchema
+
+import requests
 
 import ou_dedetai.network as network
 
@@ -40,3 +44,40 @@ class TestNetwork(unittest.TestCase):
 
     def test_urlprops_get_md5(self):
         self.assertIsNone(URLOBJ.md5)
+
+
+class TestNetworkOffline(unittest.TestCase):
+    def test_network_offline_is_connection_error(self):
+        self.assertIsInstance(network.NetworkOffline(), RequestsConnectionError)
+
+    def test_is_offline_initially_false(self):
+        nr = network.NetworkRequests(force_clean=True)
+        self.assertFalse(nr.is_offline)
+
+    def test_decorator_short_circuits_when_offline(self):
+        nr = network.NetworkRequests(force_clean=True)
+        nr._offline_until = time.monotonic() + 60
+        with self.assertRaises(network.NetworkOffline):
+            nr.faithlife_product_releases("Logos", "10", "stable")
+
+    def test_decorator_marks_offline_on_connection_error(self):
+        nr = network.NetworkRequests(force_clean=True)
+        with unittest.mock.patch.object(
+            network,
+            "_get_faithlife_product_releases",
+            side_effect=requests.exceptions.ConnectionError("no internet"),
+        ):
+            with self.assertRaises(network.NetworkOffline):
+                nr.faithlife_product_releases("Logos", "10", "stable")
+        self.assertTrue(nr.is_offline)
+
+    def test_decorator_does_not_mark_offline_on_http_error(self):
+        nr = network.NetworkRequests(force_clean=True)
+        with unittest.mock.patch.object(
+            network,
+            "_get_faithlife_product_releases",
+            side_effect=requests.exceptions.HTTPError("404"),
+        ):
+            with self.assertRaises(requests.exceptions.HTTPError):
+                nr.faithlife_product_releases("Logos", "10", "stable")
+        self.assertFalse(nr.is_offline)


### PR DESCRIPTION
A draft demonstrating how decorators can be used to facilitate not repeating the try except catches across the repo

@offline_aware guards NetworkRequests methods: a ConnectionError marks
the instance offline for 2 minutes and raises NetworkOffline. A
decorator wraps each method so the offline check and try/except frame
the body once, instead of repeating the same rule inside every method.

Ai generated untested